### PR TITLE
www-client/ungoogled-chromium-93 Allow to build with ffmpeg 4.3/4.4

### DIFF
--- a/www-client/ungoogled-chromium/files/chromium-93-ffmpeg-4.4.patch
+++ b/www-client/ungoogled-chromium/files/chromium-93-ffmpeg-4.4.patch
@@ -1,0 +1,60 @@
+--- chromium-93.0.4577.63/media/filters/ffmpeg_demuxer.cc.orig	2021-09-07 08:38:33.765397601 +0200
++++ chromium-93.0.4577.63/media/filters/ffmpeg_demuxer.cc	2021-09-07 09:03:32.575927180 +0200
+@@ -427,11 +427,19 @@
+   scoped_refptr<DecoderBuffer> buffer;
+ 
+   if (type() == DemuxerStream::TEXT) {
++#if defined FF_API_BUFFER_SIZE_T && ! FF_API_BUFFER_SIZE_T
+     size_t id_size = 0;
++#else
++    int id_size = 0;
++#endif
+     uint8_t* id_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_WEBVTT_IDENTIFIER, &id_size);
+ 
++#if defined FF_API_BUFFER_SIZE_T && ! FF_API_BUFFER_SIZE_T
+     size_t settings_size = 0;
++#else
++    int settings_size = 0;
++#endif
+     uint8_t* settings_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_WEBVTT_SETTINGS, &settings_size);
+ 
+@@ -443,7 +451,11 @@
+     buffer = DecoderBuffer::CopyFrom(packet->data, packet->size,
+                                      side_data.data(), side_data.size());
+   } else {
++#if defined FF_API_BUFFER_SIZE_T && ! FF_API_BUFFER_SIZE_T
+     size_t side_data_size = 0;
++#else
++    int side_data_size = 0;
++#endif
+     uint8_t* side_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_MATROSKA_BLOCKADDITIONAL, &side_data_size);
+ 
+@@ -504,7 +516,11 @@
+                                        packet->size - data_offset);
+     }
+ 
++#if defined FF_API_BUFFER_SIZE_T && ! FF_API_BUFFER_SIZE_T
+     size_t skip_samples_size = 0;
++#else
++    int skip_samples_size = 0;
++#endif
+     const uint32_t* skip_samples_ptr =
+         reinterpret_cast<const uint32_t*>(av_packet_get_side_data(
+             packet.get(), AV_PKT_DATA_SKIP_SAMPLES, &skip_samples_size));
+--- chromium-93.0.4577.63/media/filters/audio_decoder_unittest.cc.orig	2021-09-01 03:39:39.000000000 +0200
++++ chromium-93.0.4577.63/media/filters/audio_decoder_unittest.cc	2021-09-07 09:00:33.311446755 +0200
+@@ -109,7 +109,11 @@
+   }
+ 
+   // If the timestamp is positive, try to use FFmpeg's discard data.
++#if defined FF_API_BUFFER_SIZE_T && ! FF_API_BUFFER_SIZE_T
+   size_t skip_samples_size = 0;
++#else
++  int skip_samples_size = 0;
++#endif
+   const uint32_t* skip_samples_ptr =
+       reinterpret_cast<const uint32_t*>(av_packet_get_side_data(
+           packet, AV_PKT_DATA_SKIP_SAMPLES, &skip_samples_size));

--- a/www-client/ungoogled-chromium/ungoogled-chromium-93.0.4577.63-r1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-93.0.4577.63-r1.ebuild
@@ -282,6 +282,7 @@ src_prepare() {
 		"${WORKDIR}/sandbox-patches/chromium-fstatat-crash.patch"
 		"${FILESDIR}/chromium-93-EnumTable-crash.patch"
 		"${FILESDIR}/chromium-93-InkDropHost-crash.patch"
+		"${FILESDIR}/chromium-93-ffmpeg-4.4.patch"
 		"${FILESDIR}/chromium-use-oauth2-client-switches-as-default.patch"
 		"${FILESDIR}/chromium-shim_headers.patch"
 		"${FILESDIR}/sql-VirtualCursor-standard-layout.patch"


### PR DESCRIPTION
Currently it's not possible to build ungoogled-chromium-93 with ffmpeg 4.4 (and possibly 4.3). This pull request should make it possible to build ungoogled-chromium-93 with ffmpeg-4.3+ (future versions should also be supported).
Alternatively you could use a simpler approach Arch folks [took](https://aur.archlinux.org/cgit/aur.git/tree/chromium-93-ffmpeg-4.4.patch?h=chromium-no-extras), but it only supports ffmpeg 4.3 and 4.4, but it's not future proof (eg. ffmpeg 4.5 will not work).
When this gets accepted/merged probably we could make system-ffmpeg default again.