### PR TITLE
www-client/ungoogled-chromium-bin: update dev-libs/jsoncpp (fix #124)

### DIFF
--- a/www-client/ungoogled-chromium-bin/ungoogled-chromium-bin-97.0.4692.71.ebuild
+++ b/www-client/ungoogled-chromium-bin/ungoogled-chromium-bin-97.0.4692.71.ebuild
@@ -93,7 +93,7 @@ CDEPEND="
 	>=dev-libs/atk-2.26
 	x11-libs/gtk+:3[X]
 	media-libs/lcms
-	dev-libs/jsoncpp:0/24
+	dev-libs/jsoncpp:0/25
 	dev-libs/libevent
 	media-libs/openjpeg:2/7
 	app-arch/snappy


### PR DESCRIPTION
This PR fixs the dev-libs/jsoncpp error mentiond in #124.
I tested with my gentoo setup.

```bash
>>> Emerging (3 of 3) www-client/ungoogled-chromium-bin-97.0.4692.71::pf4public
 * ungoogled-chromium-bin-97.0.4692.71-x86-64.tar.bz2 BLAKE2B SHA512 size ;-) ...      [ ok ]
 * Determining the location of the kernel source code
 * Found kernel source directory:
 *     /usr/src/linux
 * Found sources for kernel version:
 *     5.15.11-gentoo-x86_64
>>> Unpacking source...
>>> Unpacking ungoogled-chromium-bin-97.0.4692.71-x86-64.tar.bz2 to /var/tmp/portage/www-client/ungoogled-chromium-bin-97.0.4692.71/work
>>> Source unpacked in /var/tmp/portage/www-client/ungoogled-chromium-bin-97.0.4692.71/work
>>> Preparing source in /var/tmp/portage/www-client/ungoogled-chromium-bin-97.0.4692.71/work ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/www-client/ungoogled-chromium-bin-97.0.4692.71/work ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/www-client/ungoogled-chromium-bin-97.0.4692.71/work ...
>>> Source compiled.
>>> Test phase [not enabled]: www-client/ungoogled-chromium-bin-97.0.4692.71

>>> Install www-client/ungoogled-chromium-bin-97.0.4692.71 into /var/tmp/portage/www-client/ungoogled-chromium-bin-97.0.4692.71/image
/var/tmp/portage/www-client/ungoogled-chromium-bin-97.0.4692.71/work
>>> Completed installing www-client/ungoogled-chromium-bin-97.0.4692.71 into /var/tmp/portage/www-client/ungoogled-chromium-bin-97.0.4692.71/image

 * Final size of build directory: 263376 KiB (257.2 MiB)
 * Final size of installed tree:  262492 KiB (256.3 MiB)


>>> Installing (3 of 3) www-client/ungoogled-chromium-bin-97.0.4692.71::pf4public
 * Updating icons cache ...                                                            [ ok ]
 * Updating .desktop files database ...                                                [ ok ]
 * Updating icons cache ...                                                            [ ok ]
 * Updating .desktop files database ...                                                [ ok ]
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.

 * GNU info directory index is up-to-date.
```