### PR TITLE
fix(ungoogled-chromium-99): remove ppc64 keyword

### DIFF
--- a/www-client/ungoogled-chromium/ungoogled-chromium-99.0.4844.45-r1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-99.0.4844.45-r1.ebuild
@@ -47,7 +47,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/chro
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="cfi +clang convert-dict cups cpu_flags_arm_neon custom-cflags debug enable-driver gtk4 hangouts headless js-type-check kerberos +official optimize-thinlto optimize-webui pgo pic +proprietary-codecs pulseaudio screencast selinux suid +system-ffmpeg +system-harfbuzz +system-icu +system-jsoncpp +system-libevent system-libvpx +system-openh264 system-openjpeg +system-png +system-re2 thinlto vaapi vdpau wayland widevine"
 RESTRICT="
 	!system-ffmpeg? ( proprietary-codecs? ( bindist ) )

--- a/www-client/ungoogled-chromium/ungoogled-chromium-99.0.4844.51-r1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-99.0.4844.51-r1.ebuild
@@ -47,7 +47,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/chro
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
+KEYWORDS="~amd64 ~arm64 ~x86"
 IUSE="cfi +clang convert-dict cups cpu_flags_arm_neon custom-cflags debug enable-driver gtk4 hangouts headless js-type-check kerberos +official optimize-thinlto optimize-webui pgo pic +proprietary-codecs pulseaudio screencast selinux suid +system-ffmpeg +system-harfbuzz +system-icu +system-jsoncpp +system-libevent system-libvpx +system-openh264 system-openjpeg +system-png +system-re2 thinlto vaapi vdpau wayland widevine"
 RESTRICT="
 	!system-ffmpeg? ( proprietary-codecs? ( bindist ) )


### PR DESCRIPTION
Let's remove the ~ppc64 keyword from chromium 99 for the moment.
For the future I think it would be safer to preemptively remove the keyword from new major versions until I have the chance to test it, because chances of breakage are high unfortunately.

Damn I hate Chrome so much: not only they didn't merge ppc64le support despite being offered build servers for CI, they didn't even care to reply.