### PR TITLE
dev-util/electron: fix collections.abc for py310

### DIFF
--- a/dev-util/electron/electron-16.0.9.ebuild
+++ b/dev-util/electron/electron-16.0.9.ebuild
@@ -1333,6 +1333,7 @@ src_prepare() {
 	eapply "${FILESDIR}/openssl_fips-r2.patch" || die
 	# adjust python interpreter version in electron_node
 	eapply "${FILESDIR}/electron_node_py310.patch"
+	eapply "${FILESDIR}/electron_node_collections_abc_py310.patch"
 	popd > /dev/null || die
 
 	pushd "${WORKDIR}/${P}" > /dev/null || die

--- a/dev-util/electron/files/electron_node_collections_abc_py310.patch
+++ b/dev-util/electron/files/electron_node_collections_abc_py310.patch
@@ -1,0 +1,53 @@
+--- a/tools/inspector_protocol/jinja2/utils.py	2021-09-10 19:25:14.000000000 +0200
++++ b/tools/inspector_protocol/jinja2/utils.py	2022-02-20 18:19:23.180313425 +0100
+@@ -482,7 +482,7 @@
+ 
+ # register the LRU cache as mutable mapping if possible
+ try:
+-    from collections import MutableMapping
++    from collections.abc import MutableMapping
+     MutableMapping.register(LRUCache)
+ except ImportError:
+     pass
+--- a/tools/inspector_protocol/jinja2/tests.py	2021-09-10 19:25:14.000000000 +0200
++++ b/tools/inspector_protocol/jinja2/tests.py	2022-02-20 18:19:41.816877825 +0100
+@@ -10,7 +10,7 @@
+ """
+ import operator
+ import re
+-from collections import Mapping
++from collections.abc import Mapping
+ from jinja2.runtime import Undefined
+ from jinja2._compat import text_type, string_types, integer_types
+ import decimal
+--- a/tools/inspector_protocol/jinja2/sandbox.py	2021-09-10 19:25:14.000000000 +0200
++++ b/tools/inspector_protocol/jinja2/sandbox.py	2022-02-20 18:20:16.616686863 +0100
+@@ -14,7 +14,7 @@
+ """
+ import types
+ import operator
+-from collections import Mapping
++from collections.abc import Mapping
+ from jinja2.environment import Environment
+ from jinja2.exceptions import SecurityError
+ from jinja2._compat import string_types, PY2
+@@ -79,7 +79,7 @@
+     pass
+ 
+ #: register Python 2.6 abstract base classes
+-from collections import MutableSet, MutableMapping, MutableSequence
++from collections.abc import MutableSet, MutableMapping, MutableSequence
+ _mutable_set_types += (MutableSet,)
+ _mutable_mapping_types += (MutableMapping,)
+ _mutable_sequence_types += (MutableSequence,)
+--- a/tools/inspector_protocol/jinja2/runtime.py	2021-09-10 19:25:14.000000000 +0200
++++ b/tools/inspector_protocol/jinja2/runtime.py	2022-02-20 18:20:32.306600765 +0100
+@@ -315,7 +315,7 @@
+ 
+ # register the context as mapping if possible
+ try:
+-    from collections import Mapping
++    from collections.abc import Mapping
+     Mapping.register(Context)
+ except ImportError:
+     pass


### PR DESCRIPTION
fix to use collections.abc needed for py310 compat