### PR TITLE
feat(electron-17.1.2): ppc64 keyword

### DIFF
--- a/dev-util/electron/electron-17.1.2.ebuild
+++ b/dev-util/electron/electron-17.1.2.ebuild
@@ -1139,7 +1139,7 @@ SRC_URI="https://commondatastorage.googleapis.com/chromium-browser-official/${CH
 
 LICENSE="BSD"
 SLOT="$(ver_cut 1)/$(ver_cut 2-)"
-KEYWORDS="amd64 ~x86"
+KEYWORDS="amd64 ~ppc64 ~x86"
 IUSE="+clang cups custom-cflags debug hangouts js-type-check kerberos optimize-thinlto optimize-webui +partition pgo +proprietary-codecs pulseaudio selinux +system-ffmpeg +system-harfbuzz +system-icu +system-jsoncpp +system-libevent system-libvpx +system-openh264 system-openjpeg +system-png +system-re2 tcmalloc thinlto ungoogled vaapi vdpau wayland"
 RESTRICT="
 	!system-ffmpeg? ( proprietary-codecs? ( bindist ) )


### PR DESCRIPTION
I think you can safely keep keywords for minor releases and maybe remove it once the major version of Chromium changes.