### PR TITLE
fix: build with openssl3

### DIFF
--- a/dev-util/electron/electron-17.4.2.ebuild
+++ b/dev-util/electron/electron-17.4.2.ebuild
@@ -1905,6 +1905,7 @@ src_configure() {
 	yarn config set yarn-offline-mirror "${DISTDIR}" || die
 	yarn config set disable-self-update-check true || die
 	yarn install --frozen-lockfile --offline --no-progress || die
+	find node_modules/webpack/lib -type f -exec sed -i 's|md4|sha512|g' {} \; || die # workaround md4 see https://github.com/webpack/webpack/issues/14560
 	popd > /dev/null || die
 	eend $? || die
 

--- a/dev-util/electron/electron-17.4.3.ebuild
+++ b/dev-util/electron/electron-17.4.3.ebuild
@@ -1905,6 +1905,7 @@ src_configure() {
 	yarn config set yarn-offline-mirror "${DISTDIR}" || die
 	yarn config set disable-self-update-check true || die
 	yarn install --frozen-lockfile --offline --no-progress || die
+	find node_modules/webpack/lib -type f -exec sed -i 's|md4|sha512|g' {} \; || die # workaround md4 see https://github.com/webpack/webpack/issues/14560
 	popd > /dev/null || die
 	eend $? || die
 

--- a/dev-util/electron/electron-18.2.0.ebuild
+++ b/dev-util/electron/electron-18.2.0.ebuild
@@ -1881,6 +1881,7 @@ src_configure() {
 	yarn config set disable-self-update-check true || die
 	yarn config set yarn-offline-mirror "${DISTDIR}" || die
 	yarn install --frozen-lockfile --offline --no-progress || die
+	find node_modules/webpack/lib -type f -exec sed -i 's|md4|sha512|g' {} \; || die # workaround md4 see https://github.com/webpack/webpack/issues/14560
 	popd > /dev/null || die
 	eend $? || die
 

--- a/dev-util/electron/electron-18.2.1.ebuild
+++ b/dev-util/electron/electron-18.2.1.ebuild
@@ -1881,6 +1881,7 @@ src_configure() {
 	yarn config set disable-self-update-check true || die
 	yarn config set yarn-offline-mirror "${DISTDIR}" || die
 	yarn install --frozen-lockfile --offline --no-progress || die
+	find node_modules/webpack/lib -type f -exec sed -i 's|md4|sha512|g' {} \; || die # workaround md4 see https://github.com/webpack/webpack/issues/14560
 	popd > /dev/null || die
 	eend $? || die
 


### PR DESCRIPTION
node module webpack shall not use legacy hash md4
see workaround at https://github.com/webpack/webpack/issues/14560