### PR TITLE
fix: build with openssl3

### DIFF
--- a/app-editors/vscode/vscode-1.66.2.ebuild
+++ b/app-editors/vscode/vscode-1.66.2.ebuild
@@ -2275,6 +2275,7 @@ src_configure() {
 #--no-progress
 #--skip-integrity-check
 #--verbose
+	find node_modules/webpack/lib -type f -exec sed -i 's|md4|sha512|g' {} \; || die # workaround md4 see https://github.com/webpack/webpack/issues/14560
 
 	export PATH=${OLD_PATH}
 

--- a/app-editors/vscode/vscode-1.67.0.ebuild
+++ b/app-editors/vscode/vscode-1.67.0.ebuild
@@ -2263,6 +2263,7 @@ src_configure() {
 #--no-progress
 #--skip-integrity-check
 #--verbose
+	find node_modules/webpack/lib -type f -exec sed -i 's|md4|sha512|g' {} \; || die # workaround md4 see https://github.com/webpack/webpack/issues/14560
 
 	export PATH=${OLD_PATH}
 

--- a/app-editors/vscode/vscode-9999.ebuild
+++ b/app-editors/vscode/vscode-9999.ebuild
@@ -230,6 +230,7 @@ src_configure() {
 #--no-progress
 #--skip-integrity-check
 #--verbose
+	find node_modules/webpack/lib -type f -exec sed -i 's|md4|sha512|g' {} \; || die # workaround md4 see https://github.com/webpack/webpack/issues/14560
 
 	export PATH=${OLD_PATH}
 


### PR DESCRIPTION
node module webpack shall not use legacy hash md4
see workaround at https://github.com/webpack/webpack/issues/14560