### PR TITLE
www-client/ungoogled-chromium: fix configure for [-proprietary-codecs]

### DIFF
--- a/www-client/ungoogled-chromium/ungoogled-chromium-107.0.5304.121_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-107.0.5304.121_p1.ebuild
@@ -44,6 +44,7 @@ REQUIRED_USE="
 	x86? ( !thinlto !widevine )
 	screencast? ( wayland )
 	!headless ( || ( X wayland ) )
+	!proprietary-codecs? ( !hevc )
 "
 
 #UGC_COMMIT_ID="f9d460038269ac0243ee72d7e300355fa972a24b"
@@ -974,7 +975,7 @@ src_configure() {
 
 	# Ungoogled flags
 	myconf_gn+=" enable_mdns=false"
-	myconf_gn+=" enable_mse_mpeg2ts_stream_parser=true"
+	myconf_gn+=" enable_mse_mpeg2ts_stream_parser=$(usex proprietary-codecs true false)"
 	myconf_gn+=" enable_reading_list=false"
 	myconf_gn+=" enable_remoting=false"
 	myconf_gn+=" enable_reporting=false"

--- a/www-client/ungoogled-chromium/ungoogled-chromium-108.0.5359.48_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-108.0.5359.48_p1.ebuild
@@ -44,6 +44,7 @@ REQUIRED_USE="
 	x86? ( !thinlto !widevine )
 	screencast? ( wayland )
 	!headless ( || ( X wayland ) )
+	!proprietary-codecs? ( !hevc )
 "
 
 UGC_COMMIT_ID="9a0918d2f47f7522d1d6fe1656bfb8d7967a323f"
@@ -974,7 +975,7 @@ src_configure() {
 
 	# Ungoogled flags
 	myconf_gn+=" enable_mdns=false"
-	myconf_gn+=" enable_mse_mpeg2ts_stream_parser=true"
+	myconf_gn+=" enable_mse_mpeg2ts_stream_parser=$(usex proprietary-codecs true false)"
 	myconf_gn+=" enable_reading_list=false"
 	myconf_gn+=" enable_remoting=false"
 	myconf_gn+=" enable_reporting=false"

--- a/www-client/ungoogled-chromium/ungoogled-chromium-108.0.5359.71_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-108.0.5359.71_p1.ebuild
@@ -44,6 +44,7 @@ REQUIRED_USE="
 	x86? ( !thinlto !widevine )
 	screencast? ( wayland )
 	!headless ( || ( X wayland ) )
+	!proprietary-codecs? ( !hevc )
 "
 
 UGC_COMMIT_ID="159a0e654b5b30f4926c31f611c901a946f2ea30"
@@ -974,7 +975,7 @@ src_configure() {
 
 	# Ungoogled flags
 	myconf_gn+=" enable_mdns=false"
-	myconf_gn+=" enable_mse_mpeg2ts_stream_parser=true"
+	myconf_gn+=" enable_mse_mpeg2ts_stream_parser=$(usex proprietary-codecs true false)"
 	myconf_gn+=" enable_reading_list=false"
 	myconf_gn+=" enable_remoting=false"
 	myconf_gn+=" enable_reporting=false"


### PR DESCRIPTION
Hello,
I’ve set `enable_mse_mpeg2ts_stream_parser` dependent on `proprietary-codecs` USE as it is throwing an error in configure if not set to false when `proprietary-codecs` is disabled.
I’ve also added a required USE on `!proprietary-codecs` to `!hevc` since `hevc` USE need `proprietary-codecs`.