### PR TITLE
Fix element-desktop-9999 build.

### DIFF
--- a/net-im/element-desktop/element-desktop-9999.ebuild
+++ b/net-im/element-desktop/element-desktop-9999.ebuild
@@ -118,7 +118,7 @@ src_compile() {
 	node /usr/bin/yarn install ${ONLINE_OFFLINE} --no-progress || die
 
 	node node_modules/.bin/tsc || die
-	node scripts/copy-res.js || die
+	npx ts-node scripts/copy-res.ts || die
 
 	if use native-modules
 	then


### PR DESCRIPTION
Script changed from javascript to typescript, update the ebuild accordingly.

Signed off by Joe Kappus <joe@wt.gd>