### PR TITLE
www-client/ungoogled-chromium: fix building with avx2

### DIFF
--- a/www-client/ungoogled-chromium/ungoogled-chromium-109.0.5414.74_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-109.0.5414.74_p1.ebuild
@@ -755,6 +755,7 @@ src_prepare() {
 			third_party/dav1d
 			third_party/libaom
 			third_party/libaom/source/libaom/third_party/fastfeat
+			third_party/libaom/source/libaom/third_party/SVT-AV1
 			third_party/libaom/source/libaom/third_party/vector
 			third_party/libaom/source/libaom/third_party/x86inc
 		)


### PR DESCRIPTION
Backport an upstream patch that fixes a build error when using `USE=system-av1` on a system with avx2 support.

Bug: https://bugs.gentoo.org/885833