### PR TITLE
www-client/ungoogled-chromium-bin-109.0.5414.74: remove unused IUSE flags

### DIFF
--- a/www-client/ungoogled-chromium-bin/ungoogled-chromium-bin-109.0.5414.74.ebuild
+++ b/www-client/ungoogled-chromium-bin/ungoogled-chromium-bin-109.0.5414.74.ebuild
@@ -124,7 +124,7 @@ QA_PREBUILT="*"
 S="${WORKDIR}"
 
 pkg_pretend() {
-	if ! use widevine && ! use core2 && ! use haswell; then
+	if ! use widevine; then
 		ewarn
 		ewarn "widevine was enabled in this build"
 		ewarn "If you think this is a mistake let me know in #193"


### PR DESCRIPTION
Hello,

After https://github.com/PF4Public/gentoo-overlay/commit/e46cbcd6a0796b66e88ccf0541a78b33a7150c6e there are still some IUSE flags to be removed in the ebuild: `core2` and `haswell`.

Thanks.

```
ERROR: pretend
ERROR: www-client/ungoogled-chromium-bin-109.0.5414.74::pf4public failed (pretend phase):
  USE Flag 'core2' not in IUSE for www-client/ungoogled-chromium-bin-109.0.5414.74

Call stack:
                                    ebuild.sh, line 136:  Called pkg_pretend
  ungoogled-chromium-bin-109.0.5414.74.ebuild, line 127:  Called use 'core2'
                             phase-helpers.sh, line 256:  Called die
```