### PR TITLE
Electron 22.3.8 support for gcc-13

### DIFF
--- a/dev-util/electron/electron-22.3.11.ebuild
+++ b/dev-util/electron/electron-22.3.11.ebuild
@@ -1339,6 +1339,7 @@ src_prepare() {
 		"${FILESDIR}/perfetto-system-zlib.patch"
 		"${FILESDIR}/gtk-fix-prefers-color-scheme-query.diff"
 		"${FILESDIR}/restore-x86-r2.patch"
+		"${FILESDIR}/gcc-13"
 	)
 
 	if use ppc64 ; then

--- a/dev-util/electron/electron-22.3.12.ebuild
+++ b/dev-util/electron/electron-22.3.12.ebuild
@@ -1340,6 +1340,7 @@ src_prepare() {
 		"${FILESDIR}/perfetto-system-zlib.patch"
 		"${FILESDIR}/gtk-fix-prefers-color-scheme-query.diff"
 		"${FILESDIR}/restore-x86-r2.patch"
+		"${FILESDIR}/gcc-13"
 	)
 
 	if use ppc64 ; then

--- a/dev-util/electron/files/gcc-13/gcc-13-angle-ShaderVars.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-angle-ShaderVars.patch
@@ -1,0 +1,10 @@
+--- a/third_party/angle/include/GLSLANG/ShaderVars.h	2022-12-14 02:29:58.325714800 +0100
++++ b/third_party/angle/include/GLSLANG/ShaderVars.h	2023-05-08 20:51:01.108658287 +0200
+@@ -14,6 +14,7 @@
+ #include <array>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ namespace sh
+ {

--- a/dev-util/electron/files/gcc-13/gcc-13-base.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-base.patch
@@ -1,0 +1,34 @@
+https://chromium-review.googlesource.com/c/chromium/src/+/4394430
+
+From afbe6c6ee713519263305d7e2d91cc9f1379afe2 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Mon, 03 Apr 2023 20:41:40 +0000
+Subject: [PATCH] IWYU: add stdint.h for various int types in //base
+
+Bug: 957519
+Change-Id: I750de80f0d27d93ef3383052ddb4eefd5ee13abe
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4394430
+Reviewed-by: Daniel Cheng <dcheng@chromium.org>
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Cr-Commit-Position: refs/heads/main@{#1125558}
+--- a/base/debug/profiler.h
++++ b/base/debug/profiler.h
+@@ -6,6 +6,7 @@
+ #define BASE_DEBUG_PROFILER_H_
+ 
+ #include <stddef.h>
++#include <stdint.h>
+ 
+ #include <string>
+ 
+--- a/base/strings/string_piece.h
++++ b/base/strings/string_piece.h
+@@ -22,6 +22,7 @@
+ #define BASE_STRINGS_STRING_PIECE_H_
+ 
+ #include <stddef.h>
++#include <stdint.h>
+ 
+ #include <algorithm>
+ #include <iosfwd>
+

--- a/dev-util/electron/files/gcc-13/gcc-13-cc-targetproperty.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-cc-targetproperty.patch
@@ -1,0 +1,25 @@
+https://chromium-review.googlesource.com/c/chromium/src/+/4406545
+
+From e80fc92c8ac9f727486bddeb964206fe7a52fac5 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Mon, 10 Apr 2023 15:44:41 +0000
+Subject: [PATCH] IWYU: add stdint.h for uint32_t in cc::TargetProperty
+
+Change-Id: If8b3a9cdf0d310391aeed3abf303e2ea054697b1
+Bug: 957519
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4406545
+Reviewed-by: Stefan Zager <szager@chromium.org>
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Cr-Commit-Position: refs/heads/main@{#1128159}
+--- a/cc/trees/target_property.cc
++++ b/cc/trees/target_property.cc
+@@ -4,6 +4,8 @@
+ 
+ #include "cc/trees/target_property.h"
+ 
++#include <stdint.h>
++
+ #include "ui/gfx/animation/keyframe/target_property.h"
+ 
+ namespace cc {
+

--- a/dev-util/electron/files/gcc-13/gcc-13-components.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-components.patch
@@ -1,0 +1,90 @@
+--- a/components/viz/common/shared_element_resource_id.h	2022-12-14 02:28:21.977499700 +0100
++++ b/components/viz/common/shared_element_resource_id.h	2023-05-10 20:34:22.757153317 +0200
+@@ -7,6 +7,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ #include "components/viz/common/viz_common_export.h"
+ 
+--- a/components/crash/core/app/crash_reporter_client.h	2023-05-11 11:53:02.620682873 +0200
++++ b/components/crash/core/app/crash_reporter_client.h	2023-05-11 11:53:20.258276621 +0200
+@@ -8,6 +8,7 @@
+ #include <string>
+ 
+ #include "build/build_config.h"
++#include <cstdint>
+ 
+ #if !BUILDFLAG(IS_WIN)
+ namespace base {
+
+https://chromium-review.googlesource.com/c/chromium/src/+/4406547
+
+From 81b275691c28e2a8ae91514305a0e213461fcda4 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 11 Apr 2023 13:30:43 +0000
+Subject: [PATCH] IWYU: add stdint.h for various integer types in //components
+
+Bug: 957519
+Change-Id: I920fc7c442b05c3522a6533c4b0ec83b403fd0f0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4406547
+Reviewed-by: Colin Blundell <blundell@chromium.org>
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Cr-Commit-Position: refs/heads/main@{#1128605}
+--- a/components/autofill/core/browser/autofill_ablation_study.h
++++ b/components/autofill/core/browser/autofill_ablation_study.h
+@@ -5,6 +5,8 @@
+ #ifndef COMPONENTS_AUTOFILL_CORE_BROWSER_AUTOFILL_ABLATION_STUDY_H_
+ #define COMPONENTS_AUTOFILL_CORE_BROWSER_AUTOFILL_ABLATION_STUDY_H_
+ 
++#include <stdint.h>
++
+ #include <string>
+ 
+ class GURL;
+--- a/components/feature_engagement/internal/event_storage_validator.h
++++ b/components/feature_engagement/internal/event_storage_validator.h
+@@ -5,6 +5,8 @@
+ #ifndef COMPONENTS_FEATURE_ENGAGEMENT_INTERNAL_EVENT_STORAGE_VALIDATOR_H_
+ #define COMPONENTS_FEATURE_ENGAGEMENT_INTERNAL_EVENT_STORAGE_VALIDATOR_H_
+ 
++#include <stdint.h>
++
+ #include <string>
+ 
+ namespace feature_engagement {
+--- a/components/omnibox/browser/on_device_head_model.h
++++ b/components/omnibox/browser/on_device_head_model.h
+@@ -5,6 +5,8 @@
+ #ifndef COMPONENTS_OMNIBOX_BROWSER_ON_DEVICE_HEAD_MODEL_H_
+ #define COMPONENTS_OMNIBOX_BROWSER_ON_DEVICE_HEAD_MODEL_H_
+ 
++#include <stdint.h>
++
+ #include <string>
+ #include <utility>
+ #include <vector>
+--- a/components/password_manager/core/browser/generation/password_generator.h
++++ b/components/password_manager/core/browser/generation/password_generator.h
+@@ -5,6 +5,8 @@
+ #ifndef COMPONENTS_PASSWORD_MANAGER_CORE_BROWSER_GENERATION_PASSWORD_GENERATOR_H_
+ #define COMPONENTS_PASSWORD_MANAGER_CORE_BROWSER_GENERATION_PASSWORD_GENERATOR_H_
+ 
++#include <stdint.h>
++
+ #include <string>
+ 
+ 
+diff --git a/components/payments/content/utility/fingerprint_parser.h b/components/payments/content/utility/fingerprint_parser.h
+index e7983056517e8..3c3f83087002a 100644
+--- a/components/payments/content/utility/fingerprint_parser.h
++++ b/components/payments/content/utility/fingerprint_parser.h
+@@ -6,6 +6,7 @@
+ #define COMPONENTS_PAYMENTS_CONTENT_UTILITY_FINGERPRINT_PARSER_H_
+ 
+ #include <stddef.h>
++#include <stdint.h>
+ 
+ #include <string>
+ #include <vector>

--- a/dev-util/electron/files/gcc-13/gcc-13-dawn.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-dawn.patch
@@ -1,0 +1,33 @@
+https://dawn-review.googlesource.com/c/dawn/+/126120
+
+From a7423b3d8367a706c50ab787df2fe5eedb6c3c9f Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Mon, 03 Apr 2023 13:51:27 +0000
+Subject: [PATCH] IWYU: add cstdint for uint8_t dawn::native::stream::ByteVectorSink
+
+Bug: chromium:957519
+Change-Id: I48436db0e203d793e47d717bfb75977c67145e94
+Reviewed-on: https://dawn-review.googlesource.com/c/dawn/+/126120
+Reviewed-by: Corentin Wallez <cwallez@chromium.org>
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Kokoro: Kokoro <noreply+kokoro@google.com>
+--- a/third_party/dawn/src/dawn/native/stream/ByteVectorSink.h
++++ b/third_party/dawn/src/dawn/native/stream/ByteVectorSink.h
+@@ -15,6 +15,7 @@
+ #ifndef SRC_DAWN_NATIVE_STREAM_BYTEVECTORSINK_H_
+ #define SRC_DAWN_NATIVE_STREAM_BYTEVECTORSINK_H_
+ 
++#include <cstdint>
+ #include <ostream>
+ #include <vector>
+ 
+--- chromium-108.0.5359.125/third_party/dawn/src/tint/reader/spirv/namer.h.orig	2022-12-14 02:29:58.489729000 +0100
++++ chromium-108.0.5359.125/third_party/dawn/src/tint/reader/spirv/namer.h	2023-05-10 15:01:33.296517619 +0200
+@@ -18,6 +18,7 @@
+ #include <string>
+ #include <unordered_map>
+ #include <vector>
++#include <cstdint>
+ 
+ #include "src/tint/reader/spirv/fail_stream.h"
+ 

--- a/dev-util/electron/files/gcc-13/gcc-13-documentattachmentinfo.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-documentattachmentinfo.patch
@@ -1,0 +1,28 @@
+https://chromium-review.googlesource.com/c/chromium/src/+/4395997
+
+From 5ec376a5f7170cbd30727f21bb8185ec915a9893 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 04 Apr 2023 17:30:49 +0000
+Subject: [PATCH] IWYU: add stdint.h for uint32_t in chrome_pdf::DocumentAttachmentInfo
+
+Bug: 957519
+Change-Id: I8efc538b2ae901c7d5076fdf692a31250c16cbbe
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4395997
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Commit-Queue: Lei Zhang <thestig@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1126091}
+---
+
+diff --git a/pdf/document_attachment_info.h b/pdf/document_attachment_info.h
+index e0fffc2ca..ad106fdf 100644
+--- a/pdf/document_attachment_info.h
++++ b/pdf/document_attachment_info.h
+@@ -5,6 +5,8 @@
+ #ifndef PDF_DOCUMENT_ATTACHMENT_INFO_H_
+ #define PDF_DOCUMENT_ATTACHMENT_INFO_H_
+ 
++#include <stdint.h>
++
+ #include <string>
+ 
+ 

--- a/dev-util/electron/files/gcc-13/gcc-13-encounteredsurfacetracker.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-encounteredsurfacetracker.patch
@@ -1,0 +1,26 @@
+From e920736d83fe9138c72569985fce37d9e0543c91 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 04 Apr 2023 14:51:19 +0000
+Subject: [PATCH] IWYU: add stdint.h for uint64_t in EncounteredSurfaceTracker
+
+Bug: 957519
+Change-Id: Id454f688c3067c4755c2c1353f22e0f75643aed9
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4396357
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Reviewed-by: Antonio Sartori <antoniosartori@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1125978}
+---
+
+diff --git a/chrome/browser/privacy_budget/encountered_surface_tracker.h b/chrome/browser/privacy_budget/encountered_surface_tracker.h
+index 012ca2c..32d0ac6 100644
+--- a/chrome/browser/privacy_budget/encountered_surface_tracker.h
++++ b/chrome/browser/privacy_budget/encountered_surface_tracker.h
+@@ -5,6 +5,8 @@
+ #ifndef CHROME_BROWSER_PRIVACY_BUDGET_ENCOUNTERED_SURFACE_TRACKER_H_
+ #define CHROME_BROWSER_PRIVACY_BUDGET_ENCOUNTERED_SURFACE_TRACKER_H_
+ 
++#include <stdint.h>
++
+ #include <map>
+ 
+ #include "base/containers/flat_set.h"

--- a/dev-util/electron/files/gcc-13/gcc-13-gcc-incomplete-type-v8-subtype.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-gcc-incomplete-type-v8-subtype.patch
@@ -1,0 +1,37 @@
+https://chromium-review.googlesource.com/c/v8/v8/+/4394663
+
+From c5ab3e4f0c5a3ce880941184ef8447c27cd19a93 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Mon, 03 Apr 2023 12:19:34 +0200
+Subject: [PATCH] libstdc++: fix incomplete type in v8::internal::is_subtype<T, U>
+
+Using std::convertible with incomplete types is UB. However, till
+GCC 12 it was accepted and std::convertible returned false.
+This fails now for e.g. v8::internal::WasmArray. Use
+std::disjunction and std::conjunction instead which are short-
+circuiting, because std::is_base_of<T, T> is already true.
+
+Bug: chromium:957519
+Change-Id: Ia26643dbdf0fb00d5586c71ae6b18e8d0f3cf96e
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4394663
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Reviewed-by: Clemens Backes <clemensb@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#86904}
+---
+
+diff --git a/src/codegen/tnode.h b/src/codegen/tnode.h
+index 3a8f844..c1de483 100644
+--- a/v8/src/codegen/tnode.h
++++ b/v8/src/codegen/tnode.h
+@@ -270,8 +270,9 @@
+ template <class T, class U>
+ struct is_subtype {
+   static const bool value =
+-      std::is_base_of<U, T>::value || (std::is_same<U, MaybeObject>::value &&
+-                                       std::is_convertible<T, Object>::value);
++      std::disjunction<std::is_base_of<U, T>,
++                       std::conjunction<std::is_same<U, MaybeObject>,
++                                        std::is_convertible<T, Object>>>::value;
+ };
+ template <class T1, class T2, class U>
+ struct is_subtype<UnionT<T1, T2>, U> {

--- a/dev-util/electron/files/gcc-13/gcc-13-gpu_feature_info.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-gpu_feature_info.patch
@@ -1,0 +1,29 @@
+https://chromium-review.googlesource.com/c/chromium/src/+/4401097
+
+From 2a7bf74bdb6348781dd4f3fbe9897969c4e7b819 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 11 Apr 2023 16:09:29 +0000
+Subject: [PATCH] IWYU: add stdint.h for int types in gpu_feature_info
+
+Bug: 957519
+Change-Id: Ic3bebb43bcbb3a04876e5fc35767af39b01afdd2
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4401097
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Reviewed-by: vikas soni <vikassoni@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1128679}
+---
+
+diff --git a/gpu/config/gpu_feature_info.h b/gpu/config/gpu_feature_info.h
+index d269ce2..45edc112 100644
+--- a/gpu/config/gpu_feature_info.h
++++ b/gpu/config/gpu_feature_info.h
+@@ -5,6 +5,8 @@
+ #ifndef GPU_CONFIG_GPU_FEATURE_INFO_H_
+ #define GPU_CONFIG_GPU_FEATURE_INFO_H_
+ 
++#include <stdint.h>
++
+ #include <string>
+ #include <vector>
+ 
+

--- a/dev-util/electron/files/gcc-13/gcc-13-maldoca.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-maldoca.patch
@@ -1,0 +1,19 @@
+https://github.com/google/maldoca/commit/dc14ae0a5452a2f47a1c28e0aecd691639c097cf
+
+From dc14ae0a5452a2f47a1c28e0aecd691639c097cf Mon Sep 17 00:00:00 2001
+From: b-maldoca <66144360+b-maldoca@users.noreply.github.com>
+Date: Wed, 12 Apr 2023 21:36:57 +0200
+Subject: [PATCH] fixing import in maldoca/ole/header.h (#88)
+
+--- a/third_party/maldoca/src/maldoca/ole/header.h
++++ b/third_party/maldoca/src/maldoca/ole/header.h
+@@ -43,6 +43,8 @@
+ #ifndef MALDOCA_OLE_HEADER_H_
+ #define MALDOCA_OLE_HEADER_H_
+ 
++#include <cstdint>
++
+ #include "absl/strings/string_view.h"
+ 
+ namespace maldoca {
+

--- a/dev-util/electron/files/gcc-13/gcc-13-misc.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-misc.patch
@@ -1,0 +1,251 @@
+These patches are in the same file as they touch the same files and
+need to be applied in order.
+
+https://chromium-review.googlesource.com/c/chromium/src/+/4401098
+https://chromium-review.googlesource.com/c/chromium/src/+/4401098
+https://chromium-review.googlesource.com/c/chromium/src/+/4394541
+https://chromium-review.googlesource.com/c/chromium/src/+/4400997
+https://chromium-review.googlesource.com/c/chromium/src/+/4330267
+
+From dae4f1f4114ff6c6811aa3a0410e88e7a53b0531 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Wed, 05 Apr 2023 17:46:42 +0000
+Subject: [PATCH] IWYU: add cstdint for uint8_t in web_bluetooth_device_id
+
+Bug: 957519
+Change-Id: I2dba0b0088f6975d7ce59c3a14427d2dc5838477
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4401098
+Reviewed-by: Jack Hsieh <chengweih@chromium.org>
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Cr-Commit-Position: refs/heads/main@{#1126677}
+--- a/third_party/blink/public/common/bluetooth/web_bluetooth_device_id.h
++++ b/third_party/blink/public/common/bluetooth/web_bluetooth_device_id.h
+@@ -5,6 +5,8 @@
+ #ifndef THIRD_PARTY_BLINK_PUBLIC_COMMON_BLUETOOTH_WEB_BLUETOOTH_DEVICE_ID_H_
+ #define THIRD_PARTY_BLINK_PUBLIC_COMMON_BLUETOOTH_WEB_BLUETOOTH_DEVICE_ID_H_
+ 
++#include <stdint.h>
++
+ #include <array>
+ #include <string>
+ 
+
+From 83de2fa6806fc337e61fef0bd156dc2602542db3 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Tue, 04 Apr 2023 16:10:03 +0000
+Subject: [PATCH] IWYU: add cstdint for uintptr_t in device::OneWriterSeqLock
+
+Bug: 957519
+Change-Id: I283f5b0cc34a268bea5dcb03c34726cbec905ea7
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4394541
+Reviewed-by: Ken Rockot <rockot@google.com>
+Commit-Queue: Ken Rockot <rockot@google.com>
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Cr-Commit-Position: refs/heads/main@{#1126023}
+--- a/device/base/synchronization/one_writer_seqlock.h
++++ b/device/base/synchronization/one_writer_seqlock.h
+@@ -6,6 +6,7 @@
+ #define DEVICE_BASE_SYNCHRONIZATION_ONE_WRITER_SEQLOCK_H_
+ 
+ #include <atomic>
++#include <cstdint>
+ #include <type_traits>
+ 
+ #include "base/atomicops.h"
+
+From 7815db39abc8ccf64305c5fbac7e0f88bcc8b371 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Wed, 05 Apr 2023 21:14:20 +0000
+Subject: [PATCH] IWYU: add stdint.h for integer types in //ui
+
+Bug: 957519
+Change-Id: I33698e997a32c36db19775f0cf4b22fb13cee349
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4400997
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Reviewed-by: Scott Violet <sky@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1126829}
+--- a/ui/base/prediction/kalman_filter.h
++++ b/ui/base/prediction/kalman_filter.h
+@@ -5,6 +5,8 @@
+ #ifndef UI_BASE_PREDICTION_KALMAN_FILTER_H_
+ #define UI_BASE_PREDICTION_KALMAN_FILTER_H_
+ 
++#include <stdint.h>
++
+ #include "base/component_export.h"
+ #include "ui/gfx/geometry/matrix3_f.h"
+ 
+--- a/ui/events/types/scroll_types.h
++++ b/ui/events/types/scroll_types.h
+@@ -5,6 +5,8 @@
+ #ifndef UI_EVENTS_TYPES_SCROLL_TYPES_H_
+ #define UI_EVENTS_TYPES_SCROLL_TYPES_H_
+ 
++#include <stdint.h>
++
+ namespace ui {
+ 
+ enum class ScrollGranularity : uint8_t {
+--- a/ui/gfx/geometry/linear_gradient.h
++++ b/ui/gfx/geometry/linear_gradient.h
+@@ -5,6 +5,8 @@
+ #ifndef UI_GFX_LINEAR_GRADIENT_H_
+ #define UI_GFX_LINEAR_GRADIENT_H_
+ 
++#include <stdint.h>
++
+ #include <array>
+ #include <string>
+ 
+
+From 6bbf6b001e085025cf33412b15eb79d46e2e670c Mon Sep 17 00:00:00 2001
+From: Bruno Pitrus <brunopitrus@hotmail.com>
+Date: Tue, 11 Apr 2023 19:32:13 +0000
+Subject: [PATCH] Add missing includes causing build errors with GCC/libstdc++ 13
+
+Bug: 957519
+Change-Id: If09ae682695714a19e37f3830013a003caba025a
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4330267
+Reviewed-by: Ken Rockot <rockot@google.com>
+Auto-Submit: Bruno Pitrus <brunopitrus@hotmail.com>
+Reviewed-by: Reilly Grant <reillyg@chromium.org>
+Commit-Queue: Ken Rockot <rockot@google.com>
+Reviewed-by: Robert Kaplow <rkaplow@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1128822}
+--- a/components/metrics/psi_memory_parser.h
++++ b/components/metrics/psi_memory_parser.h
+@@ -5,6 +5,7 @@
+ #ifndef COMPONENTS_METRICS_PSI_MEMORY_PARSER_H_
+ #define COMPONENTS_METRICS_PSI_MEMORY_PARSER_H_
+ 
++#include <cstdint>
+ #include <string>
+ 
+ #include "base/gtest_prod_util.h"
+--- a/components/services/app_service/public/cpp/capability_access.h
++++ b/components/services/app_service/public/cpp/capability_access.h
+@@ -5,6 +5,7 @@
+ #ifndef COMPONENTS_SERVICES_APP_SERVICE_PUBLIC_CPP_CAPABILITY_ACCESS_H_
+ #define COMPONENTS_SERVICES_APP_SERVICE_PUBLIC_CPP_CAPABILITY_ACCESS_H_
+ 
++#include <memory>
+ #include <string>
+ #include <utility>
+ 
+--- a/components/soda/constants.h
++++ b/components/soda/constants.h
+@@ -5,6 +5,7 @@
+ #ifndef COMPONENTS_SODA_CONSTANTS_H_
+ #define COMPONENTS_SODA_CONSTANTS_H_
+ 
++#include <cstdint>
+ #include <string>
+ 
+ #include "base/files/file_path.h"
+--- a/device/base/synchronization/one_writer_seqlock.h
++++ b/device/base/synchronization/one_writer_seqlock.h
+@@ -6,6 +6,7 @@
+ #define DEVICE_BASE_SYNCHRONIZATION_ONE_WRITER_SEQLOCK_H_
+ 
+ #include <atomic>
++#include <cstddef>
+ #include <cstdint>
+ #include <type_traits>
+ 
+--- a/device/bluetooth/public/cpp/bluetooth_uuid.h
++++ b/device/bluetooth/public/cpp/bluetooth_uuid.h
+@@ -5,6 +5,7 @@
+ #ifndef DEVICE_BLUETOOTH_PUBLIC_CPP_BLUETOOTH_UUID_H_
+ #define DEVICE_BLUETOOTH_PUBLIC_CPP_BLUETOOTH_UUID_H_
+ 
++#include <cstdint>
+ #include <ostream>
+ #include <string>
+ #include <vector>
+--- a/extensions/common/constants.h
++++ b/extensions/common/constants.h
+@@ -5,6 +5,9 @@
+ #ifndef EXTENSIONS_COMMON_CONSTANTS_H_
+ #define EXTENSIONS_COMMON_CONSTANTS_H_
+ 
++#include <cstddef>
++#include <cstdint>
++
+ #include "base/files/file_path.h"
+ #include "base/strings/string_piece_forward.h"
+ #include "build/chromeos_buildflags.h"
+--- a/extensions/renderer/bindings/api_invocation_errors.h
++++ b/extensions/renderer/bindings/api_invocation_errors.h
+@@ -5,6 +5,7 @@
+ #ifndef EXTENSIONS_RENDERER_BINDINGS_API_INVOCATION_ERRORS_H_
+ #define EXTENSIONS_RENDERER_BINDINGS_API_INVOCATION_ERRORS_H_
+ 
++#include <cstdint>
+ #include <set>
+ #include <string>
+ 
+--- a/net/base/parse_number.h
++++ b/net/base/parse_number.h
+@@ -5,6 +5,8 @@
+ #ifndef NET_BASE_PARSE_NUMBER_H_
+ #define NET_BASE_PARSE_NUMBER_H_
+ 
++#include <cstdint>
++
+ #include "base/strings/string_piece.h"
+ #include "net/base/net_export.h"
+ 
+--- a/net/cookies/cookie_inclusion_status.h
++++ b/net/cookies/cookie_inclusion_status.h
+@@ -6,6 +6,7 @@
+ #define NET_COOKIES_COOKIE_INCLUSION_STATUS_H_
+ 
+ #include <bitset>
++#include <cstdint>
+ #include <ostream>
+ #include <string>
+ #include <vector>
+--- a/sandbox/linux/syscall_broker/broker_file_permission.h
++++ b/sandbox/linux/syscall_broker/broker_file_permission.h
+@@ -6,6 +6,7 @@
+ #define SANDBOX_LINUX_SYSCALL_BROKER_BROKER_FILE_PERMISSION_H_
+ 
+ #include <bitset>
++#include <cstdint>
+ #include <string>
+ 
+ #include "base/strings/string_piece.h"
+--- a/third_party/blink/public/common/bluetooth/web_bluetooth_device_id.h
++++ b/third_party/blink/public/common/bluetooth/web_bluetooth_device_id.h
+@@ -8,6 +8,9 @@
+ #include <stdint.h>
+ 
+ #include <array>
++#include <cstdint>
++#include <functional>
++#include <iosfwd>
+ #include <string>
+ 
+ #include "third_party/blink/public/common/common_export.h"
+--- a/third_party/blink/public/common/origin_trials/origin_trial_public_key.h
++++ b/third_party/blink/public/common/origin_trials/origin_trial_public_key.h
+@@ -6,6 +6,7 @@
+ #define THIRD_PARTY_BLINK_PUBLIC_COMMON_ORIGIN_TRIALS_ORIGIN_TRIAL_PUBLIC_KEY_H_
+ 
+ #include <array>
++#include <cstdint>
+ 
+ namespace blink {
+ 
+--- a/ui/gfx/geometry/linear_gradient.h
++++ b/ui/gfx/geometry/linear_gradient.h
+@@ -8,6 +8,8 @@
+ #include <stdint.h>
+ 
+ #include <array>
++#include <cstddef>
++#include <cstdint>
+ #include <string>
+ 
+ #include "ui/gfx/geometry/geometry_skia_export.h"
+

--- a/dev-util/electron/files/gcc-13/gcc-13-net.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-net.patch
@@ -1,0 +1,37 @@
+https://chromium-review.googlesource.com/c/chromium/src/+/4394856
+
+From 78e8aa30665d0344a64a98c092612ea6064dbe60 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Wed, 12 Apr 2023 08:42:20 +0000
+Subject: [PATCH] IWYU: add stdint.h for various integer types in //net
+
+Bug: 957519
+Change-Id: I7161bc8f5974a4d241c12d618d954db0787ab84c
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4394856
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Reviewed-by: Steven Bingler <bingler@chromium.org>
+Reviewed-by: Matt Mueller <mattm@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1129139}
+--- a/net/cert/pki/string_util.h
++++ b/net/cert/pki/string_util.h
+@@ -7,6 +7,8 @@
+ 
+ #include "net/base/net_export.h"
+ 
++#include <stdint.h>
++
+ #include <string_view>
+ #include <vector>
+ 
+--- a/net/cookies/cookie_inclusion_status.h
++++ b/net/cookies/cookie_inclusion_status.h
+@@ -5,6 +5,8 @@
+ #ifndef NET_COOKIES_COOKIE_INCLUSION_STATUS_H_
+ #define NET_COOKIES_COOKIE_INCLUSION_STATUS_H_
+ 
++#include <stdint.h>
++
+ #include <bitset>
+ #include <cstdint>
+ #include <ostream>
+

--- a/dev-util/electron/files/gcc-13/gcc-13-openscreen.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-openscreen.patch
@@ -1,0 +1,34 @@
+https://chromium-review.googlesource.com/c/openscreen/+/4403253
+
+From f8d65c61edd2ba483f1f6167c8a5fe5ad53254ea Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Wed, 05 Apr 2023 18:53:56 +0200
+Subject: [PATCH] IWYU: add stdint.h for various integer types
+
+Bug: chromium:957519
+Change-Id: If28a50f5b1c68fffd1ba546dea18b4d906a42bbf
+Reviewed-on: https://chromium-review.googlesource.com/c/openscreen/+/4403253
+Reviewed-by: Mark Foltz <mfoltz@chromium.org>
+Commit-Queue: Mark Foltz <mfoltz@chromium.org>
+--- a/third_party/openscreen/src/discovery/dnssd/public/dns_sd_txt_record.h
++++ b/third_party/openscreen/src/discovery/dnssd/public/dns_sd_txt_record.h
+@@ -5,6 +5,8 @@
+ #ifndef DISCOVERY_DNSSD_PUBLIC_DNS_SD_TXT_RECORD_H_
+ #define DISCOVERY_DNSSD_PUBLIC_DNS_SD_TXT_RECORD_H_
+ 
++#include <stdint.h>
++
+ #include <functional>
+ #include <map>
+ #include <set>
+--- a/third_party/openscreen/src/util/base64.h
++++ b/third_party/openscreen/src/util/base64.h
+@@ -5,6 +5,8 @@
+ #ifndef UTIL_BASE64_H_
+ #define UTIL_BASE64_H_
+ 
++#include <stdint.h>
++
+ #include <string>
+ #include <vector>
+ 

--- a/dev-util/electron/files/gcc-13/gcc-13-pdfium.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-pdfium.patch
@@ -1,0 +1,28 @@
+https://pdfium-review.googlesource.com/c/pdfium/+/105890
+
+From 5d9acaac1abbbe45558f2bd6cbd3b3e9efde4414 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Wed, 05 Apr 2023 16:10:25 +0000
+Subject: [PATCH] IWYU: add stdint.h for uint32_t pdfium::annotation_flags
+
+Bug: chromium:957519
+Change-Id: Id10921a5fdf93a3b92c76c84266696e92d901bd5
+Reviewed-on: https://pdfium-review.googlesource.com/c/pdfium/+/105890
+Reviewed-by: Lei Zhang <thestig@chromium.org>
+Commit-Queue: Lei Zhang <thestig@chromium.org>
+---
+
+diff --git a/constants/annotation_flags.h b/constants/annotation_flags.h
+index 2ac244e..d44a0c1 100644
+--- a/third_party/pdfium/constants/annotation_flags.h
++++ b/third_party/pdfium/constants/annotation_flags.h
+@@ -5,6 +5,8 @@
+ #ifndef CONSTANTS_ANNOTATION_FLAGS_H_
+ #define CONSTANTS_ANNOTATION_FLAGS_H_
+ 
++#include <stdint.h>
++
+ namespace pdfium {
+ namespace annotation_flags {
+ 
+

--- a/dev-util/electron/files/gcc-13/gcc-13-perfetto-uuid.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-perfetto-uuid.patch
@@ -1,0 +1,10 @@
+--- a/third_party/perfetto/include/perfetto/ext/base/uuid.h	2022-12-14 02:30:02.394064400 +0100
++++ b/third_party/perfetto/include/perfetto/ext/base/uuid.h	2023-05-10 10:38:58.920792895 +0200
+@@ -19,6 +19,7 @@
+ 
+ #include <array>
+ #include <string>
++#include <cstdint>
+ 
+ #include "perfetto/ext/base/optional.h"
+ 

--- a/dev-util/electron/files/gcc-13/gcc-13-quiche.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-quiche.patch
@@ -1,0 +1,20 @@
+--- a/net/third_party/quiche/src/quiche/quic/core/crypto/quic_hkdf.h	2022-12-14 02:29:58.157700300 +0100
++++ b/net/third_party/quiche/src/quiche/quic/core/crypto/quic_hkdf.h	2023-05-10 12:58:39.019144897 +0200
+@@ -6,6 +6,7 @@
+ #define QUICHE_QUIC_CORE_CRYPTO_QUIC_HKDF_H_
+ 
+ #include <vector>
++#include <cstdint>
+ 
+ #include "absl/strings/string_view.h"
+ #include "quiche/quic/platform/api/quic_export.h"
+--- a/net/third_party/quiche/src/quiche/quic/core/quic_connection_id.h	2023-05-10 13:25:39.984693660 +0200
++++ b/net/third_party/quiche/src/quiche/quic/core/quic_connection_id.h	2023-05-10 13:25:52.902019356 +0200
+@@ -7,6 +7,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ #include "absl/types/span.h"
+ #include "quiche/quic/platform/api/quic_export.h"

--- a/dev-util/electron/files/gcc-13/gcc-13-ruy.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-ruy.patch
@@ -1,0 +1,18 @@
+https://github.com/google/ruy/pull/329
+
+From 7f6f4cfe5fd301bdeb2d7c19ba8b0d7963090f78 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Fri, 31 Mar 2023 14:58:38 +0000
+Subject: [PATCH] IWYU: add string for std::string
+
+--- a/third_party/ruy/src/ruy/profiler/instrumentation.h
++++ b/third_party/ruy/src/ruy/profiler/instrumentation.h
+@@ -19,6 +19,7 @@ limitations under the License.
+ #ifdef RUY_PROFILER
+ #include <cstdio>
+ #include <mutex>
++#include <string>
+ #include <vector>
+ #endif
+ 
+

--- a/dev-util/electron/files/gcc-13/gcc-13-s2cellid.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-s2cellid.patch
@@ -1,0 +1,24 @@
+https://chromium-review.googlesource.com/c/chromium/src/+/4418467
+
+From dbb0a49610aa491c5eaa1461342485721c37354c Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Fri, 14 Apr 2023 05:29:45 +0000
+Subject: [PATCH] IWYU: add cstdint for int types in s2cellid
+
+Bug: 957519
+Change-Id: I65ad411c605baeaeda3addfd07ea9b565179368b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4418467
+Commit-Queue: Stephan Hartmann <stha09@googlemail.com>
+Reviewed-by: Andrew Moylan <amoylan@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1130286}
+--- a/third_party/s2cellid/src/s2/util/math/vector.h
++++ b/third_party/s2cellid/src/s2/util/math/vector.h
+@@ -22,6 +22,7 @@
+ 
+ #include <algorithm>
+ #include <cmath>
++#include <cstdint>
+ #include <cstdlib>
+ #include <iosfwd>
+ #include <iostream>  // NOLINT(readability/streams)
+

--- a/dev-util/electron/files/gcc-13/gcc-13-swiftshader.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-swiftshader.patch
@@ -1,0 +1,25 @@
+https://swiftshader-review.googlesource.com/c/SwiftShader/+/71268
+
+From 3ecab9c1aa60d548d8efeae3a231f4df7cca6cc7 Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Sun, 02 Apr 2023 20:53:20 +0200
+Subject: [PATCH] IWYU: add cstdint for uint64_t in sw::LRUCache
+
+Bug: chromium:957519
+Change-Id: I70970ceda50dfc38f3d149fea03e8a6a79a35934
+Reviewed-on: https://swiftshader-review.googlesource.com/c/SwiftShader/+/71268
+Commit-Queue: Shahbaz Youssefi <syoussefi@google.com>
+Reviewed-by: Shahbaz Youssefi <syoussefi@google.com>
+Kokoro-Result: kokoro <noreply+kokoro@google.com>
+Tested-by: Shahbaz Youssefi <syoussefi@google.com>
+--- a/third_party/swiftshader/src/System/LRUCache.hpp
++++ b/third_party/swiftshader/src/System/LRUCache.hpp
+@@ -18,6 +18,7 @@
+ #include "System/Debug.hpp"
+ 
+ #include <cstddef>
++#include <cstdint>
+ #include <functional>
+ #include <unordered_set>
+ #include <vector>
+

--- a/dev-util/electron/files/gcc-13/gcc-13-tensorflow-tflite.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-tensorflow-tflite.patch
@@ -1,0 +1,18 @@
+https://github.com/tensorflow/tensorflow/pull/60299
+
+From 9dbee4329ffd0474b939927f6d337959fb72318a Mon Sep 17 00:00:00 2001
+From: Stephan Hartmann <stha09@googlemail.com>
+Date: Fri, 31 Mar 2023 16:01:44 +0000
+Subject: [PATCH] tflite: add stdint.h for int types in internal::Spectrogram
+
+--- a/third_party/tflite/src/tensorflow/lite/kernels/internal/spectrogram.cc
++++ b/third_party/tflite/src/tensorflow/lite/kernels/internal/spectrogram.cc
+@@ -17,6 +17,7 @@ limitations under the License.
+ 
+ #include <assert.h>
+ #include <math.h>
++#include <stdint.h>
+ 
+ #include "third_party/fft2d/fft.h"
+ 
+

--- a/dev-util/electron/files/gcc-13/gcc-13-vulkanmemoryallocator.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-vulkanmemoryallocator.patch
@@ -1,0 +1,11 @@
+https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/commit/383f06b9fd9d36fb54cb3d4ac3363a670104bc62
+--- a/third_party/vulkan_memory_allocator/include/vk_mem_alloc.h
++++ b/third_party/vulkan_memory_allocator/include/vk_mem_alloc.h
+@@ -2389,6 +2389,7 @@
+ #undef VMA_IMPLEMENTATION
+ 
+ #include <cstdint>
++#include <cstdio>
+ #include <cstdlib>
+ #include <cstring>
+ #include <utility>

--- a/dev-util/electron/files/gcc-13/gcc-13-webrtc.patch
+++ b/dev-util/electron/files/gcc-13/gcc-13-webrtc.patch
@@ -1,0 +1,10 @@
+--- a/third_party/webrtc/rtc_base/third_party/base64/base64.h	2022-12-14 02:30:05.334317000 +0100
++++ b/third_party/webrtc/rtc_base/third_party/base64/base64.h	2023-05-10 19:02:27.589541068 +0200
+@@ -14,6 +14,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ #include "absl/strings/string_view.h"
+ #include "rtc_base/system/rtc_export.h"


### PR DESCRIPTION
Add support for gcc-13, so electron builds with gcc-13 installed.