### PR TITLE
Fix ffmpeg patch for ungoogled-chromium-118

### DIFF
--- a/www-client/ungoogled-chromium/files/chromium-118-ffmpeg.patch
+++ b/www-client/ungoogled-chromium/files/chromium-118-ffmpeg.patch
@@ -1,0 +1,40 @@
+--- chromium-118.0.5993.54/media/filters/ffmpeg_demuxer.cc.orig	2023-10-04 23:53:53.691762700 +0200
++++ chromium-118.0.5993.54/media/filters/ffmpeg_demuxer.cc	2023-10-08 16:56:57.616681160 +0200
+@@ -398,7 +398,11 @@
+     // TODO(crbug.com/1471504): This is now broken without side data; remove.
+     buffer = DecoderBuffer::CopyFrom(packet->data, packet->size);
+   } else {
++#if defined FF_API_BUFFER_SIZE_T && ! FF_API_BUFFER_SIZE_T
+     size_t side_data_size = 0;
++#else
++    int side_data_size = 0;
++#endif
+     uint8_t* side_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_MATROSKA_BLOCKADDITIONAL, &side_data_size);
+ 
+@@ -461,7 +465,11 @@
+                                        packet->size - data_offset);
+     }
+ 
++#if defined FF_API_BUFFER_SIZE_T && ! FF_API_BUFFER_SIZE_T
+     size_t skip_samples_size = 0;
++#else
++    int skip_samples_size = 0;
++#endif
+     const uint32_t* skip_samples_ptr =
+         reinterpret_cast<const uint32_t*>(av_packet_get_side_data(
+             packet.get(), AV_PKT_DATA_SKIP_SAMPLES, &skip_samples_size));
+--- chromium-118.0.5993.54/media/filters/audio_decoder_unittest.cc.orig	2023-10-04 23:53:53.683762000 +0200
++++ chromium-118.0.5993.54/media/filters/audio_decoder_unittest.cc	2023-10-08 16:58:23.727519824 +0200
+@@ -108,7 +108,11 @@
+   }
+ 
+   // If the timestamp is positive, try to use FFmpeg's discard data.
++#if defined FF_API_BUFFER_SIZE_T && ! FF_API_BUFFER_SIZE_T
+   size_t skip_samples_size = 0;
++#else
++  int skip_samples_size = 0;
++#endif
+   const uint32_t* skip_samples_ptr =
+       reinterpret_cast<const uint32_t*>(av_packet_get_side_data(
+           packet, AV_PKT_DATA_SKIP_SAMPLES, &skip_samples_size));

--- a/www-client/ungoogled-chromium/ungoogled-chromium-118.0.5993.54_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-118.0.5993.54_p1.ebuild
@@ -504,7 +504,7 @@ src_prepare() {
 
 	if use system-ffmpeg; then
 		if has_version "<media-video/ffmpeg-5.0"; then
-			eapply "${FILESDIR}/chromium-93-ffmpeg-4.4.patch"
+			eapply "${FILESDIR}/chromium-118-ffmpeg.patch"
 			eapply "${FILESDIR}/unbundle-ffmpeg-av_stream_get_first_dts.patch"
 		else
 			ewarn "You need to expose \"av_stream_get_first_dts\" in ffmpeg via user patch"


### PR DESCRIPTION
This should adjust ffmpeg patch for `ungoogled-chromium-118` (final build to confirm everything works as expected still in progress)