### PR TITLE
Revert "net-im/element-web: openssl >=3.0; #194"

### DIFF
--- a/net-im/element-web/element-web-9999.ebuild
+++ b/net-im/element-web/element-web-9999.ebuild
@@ -90,11 +90,6 @@ src_configure() {
 
 	einfo "Installing node_modules"
 	node /usr/bin/yarn install ${ONLINE_OFFLINE} --no-progress --ignore-scripts || die
-
-	# Workaround md4 see https://github.com/webpack/webpack/issues/14560
-	find node_modules/webpack/lib -type f -exec sed -i 's|md4|sha512|g' {} \; || die
-	# For webpack >= 5.61.0
-	# sed -i 's/case "sha512"/case "md4"/' node_modules/webpack/lib/util/createHash.js || die
 }
 
 src_compile() {


### PR DESCRIPTION
This is not needed anymore with >=openssl 3.0, it breaks the build now.

This reverts commit 96573cca36e0f8898d1b73eb9a0cdfbf5bbe2931.