### PR TITLE
dev-util/electron-29.4.0: enable py3.12

### DIFF
--- a/dev-util/electron/electron-29.4.0.ebuild
+++ b/dev-util/electron/electron-29.4.0.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2009-2022 Gentoo Authors
+# Copyright 2009-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 PYTHON_REQ_USE="xml(+)"
 
 CHROMIUM_LANGS="af am ar bg bn ca cs da de el en-GB es es-419 et fa fi fil fr gu he


### PR DESCRIPTION
Builds/runs fine with py3.12. 