### PR TITLE
net-im/element-desktop: enable py3.12

### DIFF
--- a/net-im/element-desktop/element-desktop-1.11.66.ebuild
+++ b/net-im/element-desktop/element-desktop-1.11.66.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2009-2023 Gentoo Authors
+# Copyright 2009-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit desktop flag-o-matic multilib python-any-r1 xdg-utils
 


### PR DESCRIPTION
Tested building with 3.12, works fine. Updated copyright to this year too. 