### PR TITLE
www-client/ungoogled-chromium: Allow building against QT6 without depending on QT5

### DIFF
--- a/www-client/ungoogled-chromium/files/chromium-127-separate-qt56.patch
+++ b/www-client/ungoogled-chromium/files/chromium-127-separate-qt56.patch
@@ -1,0 +1,138 @@
+Decouple the QT6 and QT5 dependencies to support building against one without the other.  
+
+Taken from: https://issues.chromium.org/issues/328182252#comment3
+
+--- a/chrome/installer/linux/BUILD.gn
++++ b/chrome/installer/linux/BUILD.gn
+@@ -81,10 +81,12 @@
+   # Even though this is a shared library, add it to `packaging_files` instead of
+   # `packaging_files_shlibs` to skip the dependency check.  This is intentional
+   # to prevent a hard dependency on QT for the package.
+-  packaging_files += [ "$root_out_dir/libqt5_shim.so" ]
+-}
+-if (use_qt6) {
+-  packaging_files += [ "$root_out_dir/libqt6_shim.so" ]
++  if (use_qt5 {
++    packaging_files += [ "$root_out_dir/libqt5_shim.so" ]
++  }
++  if (use_qt6) {
++    packaging_files += [ "$root_out_dir/libqt6_shim.so" ]
++  }
+ }
+ 
+ action_foreach("calculate_deb_dependencies") {
+@@ -209,15 +211,17 @@
+ }
+ 
+ if (use_qt) {
+-  strip_binary("strip_qt5_shim") {
+-    binary_input = "$root_out_dir/libqt5_shim.so"
+-    deps = [ "//ui/qt:qt5_shim" ]
++  if (use_qt5) {
++    strip_binary("strip_qt5_shim") {
++      binary_input = "$root_out_dir/libqt5_shim.so"
++      deps = [ "//ui/qt:qt5_shim" ]
++    }
+   }
+-}
+-if (use_qt6) {
+-  strip_binary("strip_qt6_shim") {
+-    binary_input = "$root_out_dir/libqt6_shim.so"
+-    deps = [ "//ui/qt:qt6_shim" ]
++  if (use_qt6) {
++    strip_binary("strip_qt6_shim") {
++      binary_input = "$root_out_dir/libqt6_shim.so"
++      deps = [ "//ui/qt:qt6_shim" ]
++    }
+   }
+ }
+ 
+@@ -401,16 +405,18 @@
+     ]
+   }
+   if (use_qt) {
+-    public_deps += [
+-      ":strip_qt5_shim",
+-      "//ui/qt:qt5_shim",
+-    ]
+-  }
+-  if (use_qt6) {
+-    public_deps += [
+-      ":strip_qt6_shim",
+-      "//ui/qt:qt6_shim",
+-    ]
++    if (use_qt5) {
++      public_deps += [
++        ":strip_qt5_shim",
++        "//ui/qt:qt5_shim",
++      ]
++    }
++    if (use_qt6) {
++      public_deps += [
++        ":strip_qt6_shim",
++        "//ui/qt:qt6_shim",
++      ]
++    }
+   }
+ }
+ 
+--- a/ui/qt/BUILD.gn
++++ b/ui/qt/BUILD.gn
+@@ -61,6 +61,7 @@
+     packages = [
+       "Qt" + invoker.qt_version + "Core",
+       "Qt" + invoker.qt_version + "Widgets",
++      "Qt" + invoker.qt_version + "Gui",
+     ]
+   }
+ 
+@@ -101,10 +101,12 @@
+     }
+   }
+ }
+-qt_shim("qt5_shim") {
+-  qt_version = "5"
+-  if (!use_sysroot) {
+-    moc_qt_path = "$moc_qt5_path"
++if (use_qt5) {
++  qt_shim("qt5_shim") {
++    qt_version = "5"
++    if (!use_sysroot) {
++      moc_qt_path = "$moc_qt5_path"
++    }
+   }
+ }
+ if (use_qt6) {
+@@ -122,7 +124,10 @@
+   defines = [ "IS_QT_IMPL" ]
+ 
++  data_deps = []
+   # qt_shim is in data_deps since we want to load it manually.
+-  data_deps = [ ":qt5_shim" ]
++  if (use_qt5) {
++    data_deps += [ ":qt5_shim" ]
++  }
+   if (use_qt6) {
+     data_deps += [ ":qt6_shim" ]
+   }
+--- a/ui/qt/qt.gni
++++ b/ui/qt/qt.gni
+@@ -13,7 +13,11 @@
+ }
+ 
+ declare_args() {
+-  if (!use_sysroot && use_qt) {
++  use_qt5 = use_qt && use_sysroot
++}
++
++declare_args() {
++  if (!use_sysroot && use_qt5) {
+     moc_qt5_path = ""
+   }
+ }
+@@ -29,4 +33,5 @@
+ }
+ 
+ # use_qt6 => use_qt
++assert(!use_qt5 || use_qt)
+ assert(!use_qt6 || use_qt)

--- a/www-client/ungoogled-chromium/ungoogled-chromium-127.0.6533.88_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-127.0.6533.88_p1.ebuild
@@ -50,7 +50,6 @@ REQUIRED_USE="
 	pgo? ( clang )
 	x86? ( !thinlto !widevine )
 	debug? ( !official )
-	qt6? ( qt5 )
 	screencast? ( wayland )
 	!headless? ( || ( X wayland ) )
 	!proprietary-codecs? ( !hevc )
@@ -487,6 +486,7 @@ src_prepare() {
 		"${FILESDIR}/chromium-127-ui_lens.patch"
 		"${FILESDIR}/fix-official.patch"
 		"${FILESDIR}/restore-x86-r2.patch"
+		"${FILESDIR}/chromium-127-separate-qt56.patch"
 	)
 
 	ewarn


### PR DESCRIPTION
The patch posted to https://issues.chromium.org/issues/328182252#comment3 decouples the QT5 dependency when building a QT6-only build.   Tested on my QT6-only Gentoo system and it works without issue.