### PR TITLE
dev-build/ninja -> app-alternatives->ninja

### DIFF
--- a/dev-util/electron/electron-19.1.8.ebuild
+++ b/dev-util/electron/electron-19.1.8.ebuild
@@ -1283,7 +1283,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-19.1.9-r1.ebuild
+++ b/dev-util/electron/electron-19.1.9-r1.ebuild
@@ -1284,7 +1284,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-19.1.9.ebuild
+++ b/dev-util/electron/electron-19.1.9.ebuild
@@ -1284,7 +1284,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-20.3.12-r1.ebuild
+++ b/dev-util/electron/electron-20.3.12-r1.ebuild
@@ -1283,7 +1283,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-21.4.4.ebuild
+++ b/dev-util/electron/electron-21.4.4.ebuild
@@ -1322,7 +1322,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-23.3.12.ebuild
+++ b/dev-util/electron/electron-23.3.12.ebuild
@@ -1195,7 +1195,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-23.3.13.ebuild
+++ b/dev-util/electron/electron-23.3.13.ebuild
@@ -1196,7 +1196,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-24.8.7.ebuild
+++ b/dev-util/electron/electron-24.8.7.ebuild
@@ -1259,7 +1259,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-24.8.8.ebuild
+++ b/dev-util/electron/electron-24.8.8.ebuild
@@ -1260,7 +1260,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-25.9.7.ebuild
+++ b/dev-util/electron/electron-25.9.7.ebuild
@@ -1261,7 +1261,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-25.9.8.ebuild
+++ b/dev-util/electron/electron-25.9.8.ebuild
@@ -1262,7 +1262,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-26.6.10.ebuild
+++ b/dev-util/electron/electron-26.6.10.ebuild
@@ -1203,7 +1203,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-26.6.9.ebuild
+++ b/dev-util/electron/electron-26.6.9.ebuild
@@ -1202,7 +1202,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.1807
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-27.3.10.ebuild
+++ b/dev-util/electron/electron-27.3.10.ebuild
@@ -1226,7 +1226,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.2114
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-27.3.11.ebuild
+++ b/dev-util/electron/electron-27.3.11.ebuild
@@ -1227,7 +1227,7 @@ BDEPEND="
 	dev-lang/perl
 	>=dev-build/gn-0.2114
 	>=dev-util/gperf-3.0.3
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]
 	>=sys-devel/bison-2.4.3

--- a/dev-util/electron/electron-29.4.5.ebuild
+++ b/dev-util/electron/electron-29.4.5.ebuild
@@ -1236,7 +1236,7 @@ BDEPEND="
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
 	dev-lang/perl
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]

--- a/dev-util/electron/electron-29.4.6.ebuild
+++ b/dev-util/electron/electron-29.4.6.ebuild
@@ -1237,7 +1237,7 @@ BDEPEND="
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
 	dev-lang/perl
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git
 	>=net-libs/nodejs-7.6.0[inspector,npm]

--- a/dev-util/electron/electron-30.5.0.ebuild
+++ b/dev-util/electron/electron-30.5.0.ebuild
@@ -1238,7 +1238,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-30.5.1.ebuild
+++ b/dev-util/electron/electron-30.5.1.ebuild
@@ -1239,7 +1239,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-31.7.6.ebuild
+++ b/dev-util/electron/electron-31.7.6.ebuild
@@ -1287,7 +1287,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-31.7.7.ebuild
+++ b/dev-util/electron/electron-31.7.7.ebuild
@@ -1288,7 +1288,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-32.2.8.ebuild
+++ b/dev-util/electron/electron-32.2.8.ebuild
@@ -1335,7 +1335,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-32.3.0.ebuild
+++ b/dev-util/electron/electron-32.3.0.ebuild
@@ -1336,7 +1336,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-33.3.2.ebuild
+++ b/dev-util/electron/electron-33.3.2.ebuild
@@ -1340,7 +1340,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-33.4.0.ebuild
+++ b/dev-util/electron/electron-33.4.0.ebuild
@@ -1341,7 +1341,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-34.1.0.ebuild
+++ b/dev-util/electron/electron-34.1.0.ebuild
@@ -1267,7 +1267,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/dev-util/electron/electron-34.1.1.ebuild
+++ b/dev-util/electron/electron-34.1.1.ebuild
@@ -1268,7 +1268,7 @@ BDEPEND="
 	')
 	>=app-arch/gzip-1.7
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-128.0.6613.113.ebuild
+++ b/www-client/cromite/cromite-128.0.6613.113.ebuild
@@ -254,7 +254,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-128.0.6613.119.ebuild
+++ b/www-client/cromite/cromite-128.0.6613.119.ebuild
@@ -254,7 +254,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-128.0.6613.137.ebuild
+++ b/www-client/cromite/cromite-128.0.6613.137.ebuild
@@ -254,7 +254,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-129.0.6668.100.ebuild
+++ b/www-client/cromite/cromite-129.0.6668.100.ebuild
@@ -257,7 +257,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-129.0.6668.42.ebuild
+++ b/www-client/cromite/cromite-129.0.6668.42.ebuild
@@ -257,7 +257,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-129.0.6668.58.ebuild
+++ b/www-client/cromite/cromite-129.0.6668.58.ebuild
@@ -257,7 +257,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-129.0.6668.70.ebuild
+++ b/www-client/cromite/cromite-129.0.6668.70.ebuild
@@ -257,7 +257,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-129.0.6668.89.ebuild
+++ b/www-client/cromite/cromite-129.0.6668.89.ebuild
@@ -257,7 +257,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-130.0.6723.116.ebuild
+++ b/www-client/cromite/cromite-130.0.6723.116.ebuild
@@ -265,7 +265,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-130.0.6723.58.ebuild
+++ b/www-client/cromite/cromite-130.0.6723.58.ebuild
@@ -263,7 +263,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-131.0.6778.108.ebuild
+++ b/www-client/cromite/cromite-131.0.6778.108.ebuild
@@ -267,7 +267,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-131.0.6778.85.ebuild
+++ b/www-client/cromite/cromite-131.0.6778.85.ebuild
@@ -267,7 +267,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-132.0.6834.110.ebuild
+++ b/www-client/cromite/cromite-132.0.6834.110.ebuild
@@ -263,7 +263,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-132.0.6834.159.ebuild
+++ b/www-client/cromite/cromite-132.0.6834.159.ebuild
@@ -263,7 +263,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-132.0.6834.83.ebuild
+++ b/www-client/cromite/cromite-132.0.6834.83.ebuild
@@ -262,7 +262,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/cromite/cromite-133.0.6943.53.ebuild
+++ b/www-client/cromite/cromite-133.0.6943.53.ebuild
@@ -259,7 +259,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-128.0.6613.113_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-128.0.6613.113_p1.ebuild
@@ -275,7 +275,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-128.0.6613.119_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-128.0.6613.119_p1.ebuild
@@ -275,7 +275,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-128.0.6613.137_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-128.0.6613.137_p1.ebuild
@@ -275,7 +275,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	>=dev-build/ninja-1.7.2
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.100_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.100_p1.ebuild
@@ -278,7 +278,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.42_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.42_p1.ebuild
@@ -278,7 +278,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.58_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.58_p1.ebuild
@@ -278,7 +278,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.70_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.70_p1.ebuild
@@ -278,7 +278,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.89_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-129.0.6668.89_p1.ebuild
@@ -278,7 +278,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-130.0.6723.116_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-130.0.6723.116_p1.ebuild
@@ -286,7 +286,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-130.0.6723.58_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-130.0.6723.58_p1.ebuild
@@ -284,7 +284,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-131.0.6778.108_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-131.0.6778.108_p1.ebuild
@@ -288,7 +288,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-131.0.6778.85_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-131.0.6778.85_p1.ebuild
@@ -288,7 +288,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-132.0.6834.110_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-132.0.6834.110_p1.ebuild
@@ -285,7 +285,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-132.0.6834.159_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-132.0.6834.159_p1.ebuild
@@ -285,7 +285,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-132.0.6834.83_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-132.0.6834.83_p1.ebuild
@@ -284,7 +284,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git

--- a/www-client/ungoogled-chromium/ungoogled-chromium-133.0.6943.53_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-133.0.6943.53_p1.ebuild
@@ -281,7 +281,7 @@ BDEPEND="
 		qt6? ( dev-qt/qtbase:6 )
 	)
 	>=dev-build/gn-0.2114
-	dev-build/ninja
+	app-alternatives/ninja
 	dev-lang/perl
 	>=dev-util/gperf-3.0.3
 	dev-vcs/git


### PR DESCRIPTION
Just adjusting what is used anyway (we are calling `ninja` and not `ninja-reference`).