### PR TITLE
dev-util/electron: Mask gtk4 use flag

### DIFF
--- a/profiles/package.use.mask
+++ b/profiles/package.use.mask
@@ -1,0 +1,2 @@
+dev-util/electron gtk4
+


### PR DESCRIPTION
Electron never supported and never built with gtk4.
See https://github.com/electron/electron/issues/33690 as well as https://github.com/PF4Public/gentoo-overlay/issues/143.

It should be masked.