### PR TITLE
add a patch for system-av1

### DIFF
--- a/www-client/ungoogled-chromium/files/chromium-system-av1.patch
+++ b/www-client/ungoogled-chromium/files/chromium-system-av1.patch
@@ -1,0 +1,22 @@
+===================================================================
+--- a/media/base/libaom_thread_wrapper.cc
++++ b/media/base/libaom_thread_wrapper.cc
+@@ -4,18 +4,11 @@
+ 
+ #include "base/logging.h"
+ #include "media/base/codec_worker_impl.h"
+ #include "media/base/libvpx_thread_wrapper.h"
+-#include "third_party/libaom/source/libaom/aom_util/aom_thread.h"
+ 
+ namespace media {
+ 
+ void InitLibAomThreadWrapper() {
+-  const AVxWorkerInterface interface =
+-      CodecWorkerImpl<AVxWorkerInterface, AVxWorkerImpl, AVxWorker,
+-                      AVxWorkerStatus, AVX_WORKER_STATUS_NOT_OK,
+-                      AVX_WORKER_STATUS_OK,
+-                      AVX_WORKER_STATUS_WORKING>::GetCodecWorkerInterface();
+-  CHECK(aom_set_worker_interface(&interface));
+ }
+ 
+ }  // namespace media

--- a/www-client/ungoogled-chromium/files/chromium-system-libvpx.patch
+++ b/www-client/ungoogled-chromium/files/chromium-system-libvpx.patch
@@ -1,0 +1,23 @@
+===================================================================
+--- a/media/base/libvpx_thread_wrapper.cc
++++ b/media/base/libvpx_thread_wrapper.cc
+@@ -4,19 +4,11 @@
+ 
+ #include "media/base/libvpx_thread_wrapper.h"
+ 
+ #include "media/base/codec_worker_impl.h"
+-#include "third_party/libvpx/source/libvpx/vpx_util/vpx_thread.h"
+ 
+ namespace media {
+ 
+ void InitLibVpxThreadWrapper() {
+-  const VPxWorkerInterface interface =
+-      CodecWorkerImpl<VPxWorkerInterface, VPxWorkerImpl, VPxWorker,
+-                      VPxWorkerStatus, VPX_WORKER_STATUS_NOT_OK,
+-                      VPX_WORKER_STATUS_OK,
+-                      VPX_WORKER_STATUS_WORKING>::GetCodecWorkerInterface();
+-
+-  CHECK(vpx_set_worker_interface(&interface));
+ }
+ 
+ }  // namespace media

--- a/www-client/ungoogled-chromium/ungoogled-chromium-137.0.7151.55_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-137.0.7151.55_p1.ebuild
@@ -723,6 +723,10 @@ src_prepare() {
 		eapply_wrapper "${FILESDIR}/chromium-system-av1.patch"
 	fi
 
+	if use system-libvpx; then
+		eapply_wrapper "${FILESDIR}/chromium-system-libvpx.patch"
+	fi
+
 	#* Applying UGC PRs here
 	if [ ! -z "${UGC_PR_COMMITS[*]}" ]; then
 		pushd "${UGC_WD}" >/dev/null

--- a/www-client/ungoogled-chromium/ungoogled-chromium-137.0.7151.55_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-137.0.7151.55_p1.ebuild
@@ -719,6 +719,10 @@ src_prepare() {
 			third_party/abseil-cpp/absl/base/options.h || die
 	fi
 
+	if use system-av1; then
+		eapply_wrapper "${FILESDIR}/chromium-system-av1.patch"
+	fi
+
 	#* Applying UGC PRs here
 	if [ ! -z "${UGC_PR_COMMITS[*]}" ]; then
 		pushd "${UGC_WD}" >/dev/null


### PR DESCRIPTION
This patch adds support for system-av1. Tested using the website [HTML5 audio/video tester](https://tools.woolyss.com/html5-audio-video-tester/?u=woolyss.com/f/av1-opus-sita.webm)