### PR TITLE
137 gcc: string_view.h patch has moved.

### DIFF
--- a/www-client/ungoogled-chromium/files/chromium-137-gcc.patch
+++ b/www-client/ungoogled-chromium/files/chromium-137-gcc.patch
@@ -295,16 +295,6 @@
        : StringTypeAdapter<const LChar*>(buffer) {}
  };
  
---- a/third_party/blink/renderer/platform/wtf/text/string_view.h
-+++ b/third_party/blink/renderer/platform/wtf/text/string_view.h
-@@ -20,6 +20,7 @@
- #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"
- #include "third_party/blink/renderer/platform/wtf/get_ptr.h"
- #include "third_party/blink/renderer/platform/wtf/text/string_impl.h"
-+#include "third_party/blink/renderer/platform/wtf/text/code_point_iterator.h"
- 
- #if DCHECK_IS_ON()
- #include "base/memory/scoped_refptr.h"
 --- a/third_party/perfetto/src/tracing/internal/tracing_muxer_fake.cc
 +++ b/third_party/perfetto/src/tracing/internal/tracing_muxer_fake.cc
 @@ -27,13 +27,11 @@ PERFETTO_NORETURN void FailUninitialized


### PR DESCRIPTION
Since the string_view.h patch ended up being needed on clang too, it was moved to a more general scope. Remove it from the gcc patch.