### PR TITLE
renderer_preferences_util.cc: check profile ptr

### DIFF
--- a/www-client/ungoogled-chromium/files/chromium-137-fix-for-kde.patch
+++ b/www-client/ungoogled-chromium/files/chromium-137-fix-for-kde.patch
@@ -1,0 +1,12 @@
+--- a/chrome/browser/renderer_preferences_util.cc        2025-06-09 23:43:12.302027536 +0700
++++ b/chrome/browser/renderer_preferences_util.cc        2025-06-09 23:43:38.084028322 +0700
+@@ -183,7 +183,8 @@
+ #if defined(USE_AURA) && BUILDFLAG(IS_LINUX)
+   auto* linux_ui_theme = ui::LinuxUiTheme::GetForProfile(profile);
+   if (linux_ui_theme) {
+-    if (ThemeServiceFactory::GetForProfile(profile)->UsingSystemTheme()) {
++    if (ThemeServiceFactory::GetForProfile(profile) &&
++        ThemeServiceFactory::GetForProfile(profile)->UsingSystemTheme()) {
+       linux_ui_theme->GetFocusRingColor(&prefs->focus_ring_color);
+       linux_ui_theme->GetActiveSelectionBgColor(
+           &prefs->active_selection_bg_color);

--- a/www-client/ungoogled-chromium/ungoogled-chromium-137.0.7151.103_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-137.0.7151.103_p1.ebuild
@@ -480,6 +480,7 @@ src_prepare() {
 		"${FILESDIR}/chromium-135-crabby.patch"
 		"${FILESDIR}/chromium-136-fontations.patch"
 		"${FILESDIR}/chromium-137-no-rust.patch"
+		"${FILESDIR}/chromium-137-fix-for-kde.patch"
 	)
 
 	shopt -s globstar nullglob


### PR DESCRIPTION
This is take 2 of issue #433.
Needed for an issue on KDE w/ dark themes where the pointer for the theme factory is null.