### PR TITLE
system-abseil-cpp: fix this patch.

### DIFF
--- a/www-client/ungoogled-chromium/files/chromium-system-abseil.patch
+++ b/www-client/ungoogled-chromium/files/chromium-system-abseil.patch
@@ -1,122 +1,141 @@
---- a/third_party/abseil-cpp/absl/crc/BUILD.gn
-+++ b/third_party/abseil-cpp/absl/crc/BUILD.gn
-@@ -29,10 +29,6 @@
-     "//third_party/abseil-cpp/absl/base",
-     "//third_party/abseil-cpp/absl/base:config",
-     "//third_party/abseil-cpp/absl/base:core_headers",
--    "//third_party/abseil-cpp/absl/base:dynamic_annotations",
--    "//third_party/abseil-cpp/absl/base:endian",
--    "//third_party/abseil-cpp/absl/base:prefetch",
--    "//third_party/abseil-cpp/absl/base:raw_logging_internal",
-     "//third_party/abseil-cpp/absl/memory",
-     "//third_party/abseil-cpp/absl/numeric:bits",
-   ]
-@@ -58,9 +54,6 @@
-     ":non_temporal_memcpy",
-     "//third_party/abseil-cpp/absl/base:config",
-     "//third_party/abseil-cpp/absl/base:core_headers",
--    "//third_party/abseil-cpp/absl/base:dynamic_annotations",
--    "//third_party/abseil-cpp/absl/base:endian",
--    "//third_party/abseil-cpp/absl/base:prefetch",
-     "//third_party/abseil-cpp/absl/strings",
-   ]
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_algorithm.gn b/build/linux/unbundle/absl_algorithm.gn
+--- a/build/linux/unbundle/absl_algorithm.gn    2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_algorithm.gn    2025-06-14 13:37:41.184071477 +0700
+@@ -20,3 +20,5 @@
  }
-@@ -97,7 +90,6 @@
-     ":crc32c",
-     "//third_party/abseil-cpp/absl/memory",
-     "//third_party/abseil-cpp/absl/random",
--    "//third_party/abseil-cpp/absl/random:distributions",
-     "//third_party/abseil-cpp/absl/strings",
-   ]
+ source_set("container_test") {
  }
---- a/third_party/abseil-cpp/BUILD.gn
-+++ b/third_party/abseil-cpp/BUILD.gn
-@@ -61,7 +61,6 @@
-     "//third_party/abseil-cpp/absl/base",
-     "//third_party/abseil-cpp/absl/base:config",
-     "//third_party/abseil-cpp/absl/base:core_headers",
--    "//third_party/abseil-cpp/absl/base:prefetch",
-     "//third_party/abseil-cpp/absl/cleanup",
-     "//third_party/abseil-cpp/absl/container:btree",
-     "//third_party/abseil-cpp/absl/container:fixed_array",
-@@ -77,15 +76,11 @@
-     "//third_party/abseil-cpp/absl/functional:bind_front",
-     "//third_party/abseil-cpp/absl/functional:function_ref",
-     "//third_party/abseil-cpp/absl/hash",
--    "//third_party/abseil-cpp/absl/log:absl_check",
--    "//third_party/abseil-cpp/absl/log:absl_log",
--    "//third_party/abseil-cpp/absl/log:die_if_null",
-     "//third_party/abseil-cpp/absl/memory",
-     "//third_party/abseil-cpp/absl/meta:type_traits",
-     "//third_party/abseil-cpp/absl/numeric:bits",
-     "//third_party/abseil-cpp/absl/numeric:int128",
-     "//third_party/abseil-cpp/absl/random",
--    "//third_party/abseil-cpp/absl/random:distributions",
-     "//third_party/abseil-cpp/absl/status",
-     "//third_party/abseil-cpp/absl/status:statusor",
-     "//third_party/abseil-cpp/absl/strings",
-@@ -201,12 +196,9 @@
-         "absl/crc:crc_cord_state_test",
-         "absl/crc:crc_memcpy_test",
-         "absl/crc:non_temporal_memcpy_test",
--        "absl/debugging:stacktrace_test",
-         "absl/functional:any_invocable_test",
-         "absl/hash:hash_test",
-         "absl/hash:low_level_hash_test",
--        "absl/log:absl_check_test",
--        "absl/log:absl_log_basic_test",
-         "absl/log:die_if_null_test",
-         "absl/log:flags_test",
-         "absl/log:globals_test",
-@@ -221,7 +213,6 @@
-         "absl/log/internal:stderr_log_sink_test",
-         "absl/memory:memory_test",
-         "absl/meta:type_traits_test",
--        "absl/numeric:int128_test",
-         "absl/profiling:exponential_biased_test",
-         "absl/profiling:periodic_sampler_test",
-         "absl/status:statusor_test",
-@@ -238,13 +229,9 @@
-         "absl/strings:cordz_test",
-         "absl/strings:cordz_update_scope_test",
-         "absl/strings:cordz_update_tracker_test",
--        "absl/strings:damerau_levenshtein_distance_test",
-         "absl/strings:match_test",
-         "absl/strings:str_replace_test",
-         "absl/strings:string_view_test",
--        "absl/synchronization:kernel_timeout_internal_test",
--        "absl/synchronization:waiter_test",
--        "absl/time:time_test",
-         "absl/types:optional_test",
-         "absl/types:variant_test",
-         "//third_party/googletest:gtest_main",
---- a/build/linux/unbundle/absl_base.gn
-+++ b/build/linux/unbundle/absl_base.gn
-@@ -1,5 +1,6 @@
- import("//build/config/linux/pkg_config.gni")
- import("//build/shim_headers.gni")
-+import("//third_party/abseil-cpp/absl.gni")
- 
- pkg_config("system_absl_base") {
-   packages = [ "absl_base" ]
-@@ -27,18 +28,12 @@
-   public_configs = [ ":system_absl_base" ]
++source_set("algorithm") {
++}
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_base.gn b/build/linux/unbundle/absl_base.gn
+--- a/build/linux/unbundle/absl_base.gn 2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_base.gn 2025-06-14 14:01:02.844114253 +0700
+@@ -103,3 +103,25 @@
  }
- 
--shim_headers("config_shim") {
--  root_path = "."
--  prefix = "absl/base/"
--  headers = [
-+absl_source_set("config") {
-+  public = [
-     "config.h",
-     "options.h",
-     "policy_checks.h",
+ source_set("prefetch_test") {
+ }
++source_set("dynamic_annotations") {
++}
++source_set("fast_type_id") {
++}
++source_set("log_severity") {
++}
++source_set("raw_logging_internal") {
++}
++source_set("attributes_test") {
++}
++source_set("iterator_traits_test") {
++}
++source_set("nullability_default_nonnull_test") {
++}
++source_set("poison_test") {
++}
++source_set("tracing_internal_strong_test") {
++}
++source_set("tracing_internal_weak_test") {
++}
++source_set("endian") {
++}
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_container.gn b/build/linux/unbundle/absl_container.gn
+--- a/build/linux/unbundle/absl_container.gn    2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_container.gn    2025-06-14 13:46:36.300087808 +0700
+@@ -129,3 +129,11 @@
+ }
+ source_set("sample_element_size_test") {
+ }
++source_set("layout") {
++}
++source_set("node_hash_map_test") {
++}
++source_set("node_hash_set_test") {
++}
++source_set("raw_hash_set_resize_impl_test") {
++}
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_debugging.gn b/build/linux/unbundle/absl_debugging.gn
+--- a/build/linux/unbundle/absl_debugging.gn    2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_debugging.gn    2025-06-14 13:47:25.622089313 +0700
+@@ -50,3 +50,9 @@
+ }
+ source_set("stacktrace_test") {
+ }
++source_set("bounded_utf8_length_sequence_test") {
++}
++source_set("decode_rust_punycode_test") {
++}
++source_set("utf8_for_code_point_test") {
++}
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_log.gn b/build/linux/unbundle/absl_log.gn
+--- a/build/linux/unbundle/absl_log.gn  2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_log.gn  2025-06-14 13:51:41.028097107 +0700
+@@ -138,3 +138,11 @@
+ }
+ source_set("vlog_is_on_test") {
+ }
++source_set("absl_vlog_is_on") {
++}
++source_set("log_entry") {
++}
++source_set("log_sink") {
++}
++source_set("log_sink_registry") {
++}
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_log_internal.gn b/build/linux/unbundle/absl_log_internal.gn
+--- a/build/linux/unbundle/absl_log_internal.gn 2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_log_internal.gn 2025-06-14 14:00:50.974113890 +0700
+@@ -2,3 +2,5 @@
+ }
+ source_set("stderr_log_sink_test") {
+ }
++source_set("structured_proto_test") {
++}
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_random.gn b/build/linux/unbundle/absl_random.gn
+--- a/build/linux/unbundle/absl_random.gn       2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_random.gn       2025-06-14 13:38:02.352072123 +0700
+@@ -62,3 +62,7 @@
+ }
+ group("mock_distributions_test") {
+ }
++source_set("seed_gen_exception") {
++}
++source_set("mocking_bit_gen") {
++}
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_strings.gn b/build/linux/unbundle/absl_strings.gn
+--- a/build/linux/unbundle/absl_strings.gn      2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_strings.gn      2025-06-14 14:18:00.168145299 +0700
+@@ -44,6 +44,8 @@
+     "string_view.h",
+     "strip.h",
+     "substitute.h",
++    "has_absl_stringify.h",
++    "has_ostream_operator.h",
    ]
--}
--
--source_set("config") {
--  deps = [ ":config_shim" ]
-   public_configs = [ ":system_absl_config" ]
  }
  
+@@ -136,3 +138,11 @@
+ }
+ source_set("string_view_test") {
+ }
++source_set("cord_test") {
++}
++source_set("cordz_handle_test") {
++}
++source_set("cordz_sample_token_test") {
++}
++source_set("str_cat_test") {
++}
+diff '--color=auto' -Naur a/build/linux/unbundle/absl_synchronization.gn b/build/linux/unbundle/absl_synchronization.gn
+--- a/build/linux/unbundle/absl_synchronization.gn      2025-06-14 13:18:16.732035941 +0700
++++ b/build/linux/unbundle/absl_synchronization.gn      2025-06-14 13:57:06.570107042 +0700
+@@ -25,3 +25,11 @@
+ }
+ source_set("waiter_test") {
+ }
++source_set("barrier_test") {
++}
++source_set("graphcycles_test") {
++}
++source_set("mutex_test") {
++}
++source_set("per_thread_sem_test") {
++}
+

--- a/www-client/ungoogled-chromium/ungoogled-chromium-137.0.7151.103_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-137.0.7151.103_p1.ebuild
@@ -385,13 +385,6 @@ pkg_pretend() {
 		ewarn "Not all patches are applied, let me know if others should be considered too"
 		ewarn
 	fi
-	if use system-abseil-cpp; then
-		ewarn
-		ewarn "Chromium code is not very friendly to system abseil-cpp, see #218"
-		ewarn "If you know how to fix this, feel free to submit a PR"
-		ewarn
-		[[ -z "${NODIE}" ]] && die "The build will fail!"
-	fi
 	pre_build_checks
 
 	if use headless; then
@@ -728,8 +721,9 @@ src_prepare() {
 	if use system-abseil-cpp; then
 		eapply_wrapper "${FILESDIR}/chromium-system-abseil.patch"
 		cp -f /usr/include/absl/base/options.h third_party/abseil-cpp/absl/base/options.h
-		sed -i '/^#define ABSL_OPTION_USE_STD_OPTIONAL.*$/{s++#define ABSL_OPTION_USE_STD_OPTIONAL 0+;h};${x;/./{x;q0};x;q1}' \
+		sed -i '/^#define ABSL_OPTION_USE_STD_ORDERING.*$/{s++#define ABSL_OPTION_USE_STD_ORDERING 1+;h};${x;/./{x;q0};x;q1}' \
 			third_party/abseil-cpp/absl/base/options.h || die
+
 	fi
 
 	#* Applying UGC PRs here
@@ -1373,6 +1367,7 @@ src_configure() {
 		absl_base
 		absl_cleanup
 		absl_container
+		absl_crc
 		absl_debugging
 		absl_flags
 		absl_functional


### PR DESCRIPTION
So I worked on system-abseil-cpp patches and got it in working condition. At least on GCC, I haven't tested it with clang yet.

Here is proof that it indeed links to abseil:

```bash
philmb@aliens ~ $ ldd /usr/lib64/chromium-browser/chrome | ag absl
	libabsl_raw_logging_internal.so.2505.0.0 => /usr/lib64/libabsl_raw_logging_internal.so.2505.0.0 (0x000073979d18a000)
	libabsl_spinlock_wait.so.2505.0.0 => /usr/lib64/libabsl_spinlock_wait.so.2505.0.0 (0x000073979d185000)
	libabsl_cord.so.2505.0.0 => /usr/lib64/libabsl_cord.so.2505.0.0 (0x000073979d167000)
	libabsl_cordz_info.so.2505.0.0 => /usr/lib64/libabsl_cordz_info.so.2505.0.0 (0x000073979d15d000)
	libabsl_cord_internal.so.2505.0.0 => /usr/lib64/libabsl_cord_internal.so.2505.0.0 (0x000073979d149000)
	libabsl_synchronization.so.2505.0.0 => /usr/lib64/libabsl_synchronization.so.2505.0.0 (0x000073979d133000)
	libabsl_kernel_timeout_internal.so.2505.0.0 => /usr/lib64/libabsl_kernel_timeout_internal.so.2505.0.0 (0x000073979d12e000)
	libabsl_time.so.2505.0.0 => /usr/lib64/libabsl_time.so.2505.0.0 (0x000073979d11a000)
	libabsl_str_format_internal.so.2505.0.0 => /usr/lib64/libabsl_str_format_internal.so.2505.0.0 (0x000073979d0fb000)
	libabsl_strings.so.2505.0.0 => /usr/lib64/libabsl_strings.so.2505.0.0 (0x000073979d0d8000)
	libabsl_int128.so.2505.0.0 => /usr/lib64/libabsl_int128.so.2505.0.0 (0x000073979d0d1000)
	libabsl_throw_delegate.so.2505.0.0 => /usr/lib64/libabsl_throw_delegate.so.2505.0.0 (0x000073979d0cb000)
	libabsl_raw_hash_set.so.2505.0.0 => /usr/lib64/libabsl_raw_hash_set.so.2505.0.0 (0x000073979d0bb000)
	libabsl_hash.so.2505.0.0 => /usr/lib64/libabsl_hash.so.2505.0.0 (0x000073979d0b4000)
	libabsl_log_internal_check_op.so.2505.0.0 => /usr/lib64/libabsl_log_internal_check_op.so.2505.0.0 (0x000073979d0ab000)
	libabsl_log_internal_message.so.2505.0.0 => /usr/lib64/libabsl_log_internal_message.so.2505.0.0 (0x000073979d09c000)
	libabsl_log_internal_nullguard.so.2505.0.0 => /usr/lib64/libabsl_log_internal_nullguard.so.2505.0.0 (0x000073979d097000)
	libabsl_status.so.2505.0.0 => /usr/lib64/libabsl_status.so.2505.0.0 (0x000073979d08c000)
	libabsl_statusor.so.2505.0.0 => /usr/lib64/libabsl_statusor.so.2505.0.0 (0x000073979d086000)
	libabsl_crc_cord_state.so.2505.0.0 => /usr/lib64/libabsl_crc_cord_state.so.2505.0.0 (0x00007397981ae000)
	libabsl_cordz_functions.so.2505.0.0 => /usr/lib64/libabsl_cordz_functions.so.2505.0.0 (0x00007397981a9000)
	libabsl_cordz_handle.so.2505.0.0 => /usr/lib64/libabsl_cordz_handle.so.2505.0.0 (0x00007397981a4000)
	libabsl_stacktrace.so.2505.0.0 => /usr/lib64/libabsl_stacktrace.so.2505.0.0 (0x000073979819c000)
	libabsl_base.so.2505.0.0 => /usr/lib64/libabsl_base.so.2505.0.0 (0x0000739798195000)
	libabsl_graphcycles_internal.so.2505.0.0 => /usr/lib64/libabsl_graphcycles_internal.so.2505.0.0 (0x000073979818c000)
	libabsl_symbolize.so.2505.0.0 => /usr/lib64/libabsl_symbolize.so.2505.0.0 (0x0000739798183000)
	libabsl_tracing_internal.so.2505.0.0 => /usr/lib64/libabsl_tracing_internal.so.2505.0.0 (0x000073979817e000)
	libabsl_malloc_internal.so.2505.0.0 => /usr/lib64/libabsl_malloc_internal.so.2505.0.0 (0x0000739798175000)
	libabsl_time_zone.so.2505.0.0 => /usr/lib64/libabsl_time_zone.so.2505.0.0 (0x000073979815b000)
	libabsl_strings_internal.so.2505.0.0 => /usr/lib64/libabsl_strings_internal.so.2505.0.0 (0x0000739798155000)
	libabsl_hashtablez_sampler.so.2505.0.0 => /usr/lib64/libabsl_hashtablez_sampler.so.2505.0.0 (0x000073979814f000)
	libabsl_city.so.2505.0.0 => /usr/lib64/libabsl_city.so.2505.0.0 (0x000073979814a000)
	libabsl_low_level_hash.so.2505.0.0 => /usr/lib64/libabsl_low_level_hash.so.2505.0.0 (0x0000739798143000)
	libabsl_leak_check.so.2505.0.0 => /usr/lib64/libabsl_leak_check.so.2505.0.0 (0x000073979813e000)
	libabsl_examine_stack.so.2505.0.0 => /usr/lib64/libabsl_examine_stack.so.2505.0.0 (0x0000739798139000)
	libabsl_log_internal_format.so.2505.0.0 => /usr/lib64/libabsl_log_internal_format.so.2505.0.0 (0x0000739798134000)
	libabsl_log_internal_structured_proto.so.2505.0.0 => /usr/lib64/libabsl_log_internal_structured_proto.so.2505.0.0 (0x000073979812f000)
	libabsl_strerror.so.2505.0.0 => /usr/lib64/libabsl_strerror.so.2505.0.0 (0x0000739798128000)
	libabsl_log_internal_proto.so.2505.0.0 => /usr/lib64/libabsl_log_internal_proto.so.2505.0.0 (0x0000739798123000)
	libabsl_log_internal_log_sink_set.so.2505.0.0 => /usr/lib64/libabsl_log_internal_log_sink_set.so.2505.0.0 (0x000073979811c000)
	libabsl_log_internal_globals.so.2505.0.0 => /usr/lib64/libabsl_log_internal_globals.so.2505.0.0 (0x0000739798117000)
	libabsl_log_globals.so.2505.0.0 => /usr/lib64/libabsl_log_globals.so.2505.0.0 (0x0000739798111000)
	libabsl_crc32c.so.2505.0.0 => /usr/lib64/libabsl_crc32c.so.2505.0.0 (0x0000739793ec9000)
	libabsl_exponential_biased.so.2505.0.0 => /usr/lib64/libabsl_exponential_biased.so.2505.0.0 (0x0000739793ec4000)
	libabsl_debugging_internal.so.2505.0.0 => /usr/lib64/libabsl_debugging_internal.so.2505.0.0 (0x0000739793ebd000)
	libabsl_demangle_internal.so.2505.0.0 => /usr/lib64/libabsl_demangle_internal.so.2505.0.0 (0x0000739793eb0000)
	libabsl_log_sink.so.2505.0.0 => /usr/lib64/libabsl_log_sink.so.2505.0.0 (0x0000739793ea9000)
	libabsl_crc_internal.so.2505.0.0 => /usr/lib64/libabsl_crc_internal.so.2505.0.0 (0x0000739793913000)
	libabsl_crc_cpu_detect.so.2505.0.0 => /usr/lib64/libabsl_crc_cpu_detect.so.2505.0.0 (0x000073979390e000)
	libabsl_demangle_rust.so.2505.0.0 => /usr/lib64/libabsl_demangle_rust.so.2505.0.0 (0x0000739793907000)
	libabsl_decode_rust_punycode.so.2505.0.0 => /usr/lib64/libabsl_decode_rust_punycode.so.2505.0.0 (0x0000739793899000)
	libabsl_utf8_for_code_point.so.2505.0.0 => /usr/lib64/libabsl_utf8_for_code_point.so.2505.0.0 (0x0000739793894000)
philmb@aliens ~ $
```