### PR TITLE
dev-util/electron: Apply SwiftShader ppc64le patch

### DIFF
--- a/dev-util/electron/electron-36.9.4.ebuild
+++ b/dev-util/electron/electron-36.9.4.ebuild
@@ -1585,6 +1585,8 @@ src_prepare() {
 		if use cpu_flags_ppc_vsx3 ; then
 			PATCHES+=( "${patchset_dir}/${isa_3_patch}" )
 		fi
+		# Raptor's SwiftShader patch only covers LLVM 16; this patch covers LLVM 10.
+		PATCHES+=( "${FILESDIR}/ppc64le/fix-swiftshader-compile.patch" )
 	fi
 
 	ewarn

--- a/dev-util/electron/electron-36.9.5.ebuild
+++ b/dev-util/electron/electron-36.9.5.ebuild
@@ -1586,6 +1586,8 @@ src_prepare() {
 		if use cpu_flags_ppc_vsx3 ; then
 			PATCHES+=( "${patchset_dir}/${isa_3_patch}" )
 		fi
+		# Raptor's SwiftShader patch only covers LLVM 16; this patch covers LLVM 10.
+		PATCHES+=( "${FILESDIR}/ppc64le/fix-swiftshader-compile.patch" )
 	fi
 
 	ewarn

--- a/dev-util/electron/electron-37.8.0.ebuild
+++ b/dev-util/electron/electron-37.8.0.ebuild
@@ -1578,6 +1578,8 @@ src_prepare() {
 		if use cpu_flags_ppc_vsx3 ; then
 			PATCHES+=( "${patchset_dir}/${isa_3_patch}" )
 		fi
+		# Raptor's SwiftShader patch only covers LLVM 16; this patch covers LLVM 10.
+		PATCHES+=( "${FILESDIR}/ppc64le/fix-swiftshader-compile.patch" )
 	fi
 
 	ewarn

--- a/dev-util/electron/electron-37.9.0.ebuild
+++ b/dev-util/electron/electron-37.9.0.ebuild
@@ -1579,6 +1579,8 @@ src_prepare() {
 		if use cpu_flags_ppc_vsx3 ; then
 			PATCHES+=( "${patchset_dir}/${isa_3_patch}" )
 		fi
+		# Raptor's SwiftShader patch only covers LLVM 16; this patch covers LLVM 10.
+		PATCHES+=( "${FILESDIR}/ppc64le/fix-swiftshader-compile.patch" )
 	fi
 
 	ewarn

--- a/dev-util/electron/electron-38.5.0.ebuild
+++ b/dev-util/electron/electron-38.5.0.ebuild
@@ -1609,6 +1609,8 @@ src_prepare() {
 		if use cpu_flags_ppc_vsx3 ; then
 			PATCHES+=( "${patchset_dir}/${isa_3_patch}" )
 		fi
+		# Raptor's SwiftShader patch only covers LLVM 16; this patch covers LLVM 10.
+		PATCHES+=( "${FILESDIR}/ppc64le/fix-swiftshader-compile.patch" )
 	fi
 
 	ewarn

--- a/dev-util/electron/electron-38.6.0.ebuild
+++ b/dev-util/electron/electron-38.6.0.ebuild
@@ -1610,6 +1610,8 @@ src_prepare() {
 		if use cpu_flags_ppc_vsx3 ; then
 			PATCHES+=( "${patchset_dir}/${isa_3_patch}" )
 		fi
+		# Raptor's SwiftShader patch only covers LLVM 16; this patch covers LLVM 10.
+		PATCHES+=( "${FILESDIR}/ppc64le/fix-swiftshader-compile.patch" )
 	fi
 
 	ewarn

--- a/dev-util/electron/electron-39.1.1.ebuild
+++ b/dev-util/electron/electron-39.1.1.ebuild
@@ -1600,6 +1600,8 @@ src_prepare() {
 		if use cpu_flags_ppc_vsx3 ; then
 			PATCHES+=( "${patchset_dir}/${isa_3_patch}" )
 		fi
+		# Raptor's SwiftShader patch only covers LLVM 16; this patch covers LLVM 10.
+		PATCHES+=( "${FILESDIR}/ppc64le/fix-swiftshader-compile.patch" )
 	fi
 
 	ewarn

--- a/dev-util/electron/electron-39.1.2.ebuild
+++ b/dev-util/electron/electron-39.1.2.ebuild
@@ -1600,6 +1600,8 @@ src_prepare() {
 		if use cpu_flags_ppc_vsx3 ; then
 			PATCHES+=( "${patchset_dir}/${isa_3_patch}" )
 		fi
+		# Raptor's SwiftShader patch only covers LLVM 16; this patch covers LLVM 10.
+		PATCHES+=( "${FILESDIR}/ppc64le/fix-swiftshader-compile.patch" )
 	fi
 
 	ewarn


### PR DESCRIPTION
For some reason it wasn't actually pulled in by the ebuilds despite being in the repo.

Fixes the following build fail:

```
[9095/41762] "python3.13" "../../build/toolchain/gcc_solink_wrapper.py" --readelf="readelf" --nm="powerpc64le-unknown-linux-gnu-nm"  --sofile="./libvk_swiftshader.so" --tocfile="./libvk_swiftshader.so.TOC" --output="./libvk_swiftshader.so" -- powerpc64le-unknown-linux-gnu-clang++ -shared -Wl,-soname="libvk_swiftshader.so" -Wl,--start-group -Wl,-Bsymbolic -Wl,--version-script=../../third_party/swiftshader/src/Vulkan/vk_swiftshader.lds -fuse-ld=lld -Wl,--build-id=sha1 -fPIC -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--icf=all -Wl,--color-diagnostics -Wl,--undefined-version -Wl,--no-call-graph-profile-sort -no-canonical-prefixes -Wl,-O2 -Wl,--gc-sections -Wl,-z,defs -Wl,--as-needed -Wl,--as-needed -o "./libvk_swiftshader.so" @"./libvk_swiftshader.so.rsp"  -Wl,--end-group FAILED: [code=1] libvk_swiftshader.so libvk_swiftshader.so.TOC "python3.13" "../../build/toolchain/gcc_solink_wrapper.py" --readelf="readelf" --nm="powerpc64le-unknown-linux-gnu-nm"  --sofile="./libvk_swiftshader.so" --tocfile="./libvk_swiftshader.so.TOC" --output="./libvk_swiftshader.so" -- powerpc64le-unknown-linux-gnu-clang++ -shared -Wl,-soname="libvk_swiftshader.so" -Wl,--start-group -Wl,-Bsymbolic -Wl,--version-script=../../third_party/swiftshader/src/Vulkan/vk_swiftshader.lds -fuse-ld=lld -Wl,--build-id=sha1 -fPIC -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--icf=all -Wl,--color-diagnostics -Wl,--undefined-version -Wl,--no-call-graph-profile-sort -no-canonical-prefixes -Wl,-O2 -Wl,--gc-sections -Wl,-z,defs -Wl,--as-needed -Wl,--as-needed -o "./libvk_swiftshader.so" @"./libvk_swiftshader.so.rsp"  -Wl,--end-group ld.lld: error: undefined symbol: llvm::MCAsmInfoXCOFF::MCAsmInfoXCOFF()
>>> referenced by PPCMCAsmInfo.cpp
>>>               obj/third_party/swiftshader/third_party/llvm-10.0/swiftshader_llvm_ppc/PPCMCAsmInfo.o:(llvm::PPCXCOFFMCAsmInfo::PPCXCOFFMCAsmInfo(bool, llvm::Triple const&))

ld.lld: error: undefined symbol: llvm::MCAsmInfoXCOFF::isAcceptableChar(char) const
>>> referenced by PPCMCAsmInfo.cpp
>>>               obj/third_party/swiftshader/third_party/llvm-10.0/swiftshader_llvm_ppc/PPCMCAsmInfo.o:(vtable for llvm::PPCXCOFFMCAsmInfo)

ld.lld: error: undefined symbol: llvm::MCXCOFFObjectTargetWriter::MCXCOFFObjectTargetWriter(bool)
>>> referenced by PPCXCOFFObjectWriter.cpp
>>>               obj/third_party/swiftshader/third_party/llvm-10.0/swiftshader_llvm_ppc/PPCXCOFFObjectWriter.o:(llvm::createPPCXCOFFObjectWriter(bool))

ld.lld: error: undefined symbol: llvm::MCXCOFFObjectTargetWriter::~MCXCOFFObjectTargetWriter()
>>> referenced by PPCXCOFFObjectWriter.cpp
>>>               obj/third_party/swiftshader/third_party/llvm-10.0/swiftshader_llvm_ppc/PPCXCOFFObjectWriter.o:((anonymous namespace)::PPCXCOFFObjectWriter::~PPCXCOFFObjectWriter())
>>> referenced by PPCXCOFFObjectWriter.cpp
>>>               obj/third_party/swiftshader/third_party/llvm-10.0/swiftshader_llvm_ppc/PPCXCOFFObjectWriter.o:(vtable for (anonymous namespace)::PPCXCOFFObjectWriter)
powerpc64le-unknown-linux-gnu-clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR gets 36.9.4 and 36.9.5 building on ppc64le. The other versions still have unrelated problems, but I am pretty sure this patch is still helpful for those versions too.