### PR TITLE
www-client/ungoogled-chromium: fix build with rust 1.95

### DIFF
--- a/www-client/ungoogled-chromium/files/fix-rust-1.95-bytemuck.patch
+++ b/www-client/ungoogled-chromium/files/fix-rust-1.95-bytemuck.patch
@@ -1,0 +1,21 @@
+The original patch got reverted upstream, but LaneCount and SupportedLaneCount no longer work in Rust 1.95.0
+--- a/third_party/rust/chromium_crates_io/vendor/bytemuck-v1/src/pod.rs
++++ b/third_party/rust/chromium_crates_io/vendor/bytemuck-v1/src/pod.rs
+@@ -152,7 +152,6 @@ impl_unsafe_marker_for_simd!(
+ unsafe impl<T, const N: usize> Pod for core::simd::Simd<T, N>
+ where
+   T: core::simd::SimdElement + Pod,
+-  core::simd::LaneCount<N>: core::simd::SupportedLaneCount,
+ {
+ }
+ 
+--- a/third_party/rust/chromium_crates_io/vendor/bytemuck-v1/src/zeroable.rs
++++ b/third_party/rust/chromium_crates_io/vendor/bytemuck-v1/src/zeroable.rs
+@@ -231,7 +231,6 @@ impl_unsafe_marker_for_simd!(
+ unsafe impl<T, const N: usize> Zeroable for core::simd::Simd<T, N>
+ where
+   T: core::simd::SimdElement + Zeroable,
+-  core::simd::LaneCount<N>: core::simd::SupportedLaneCount,
+ {
+ }
+ 

--- a/www-client/ungoogled-chromium/ungoogled-chromium-149.0.7827.196_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-149.0.7827.196_p1.ebuild
@@ -733,7 +733,7 @@ src_prepare() {
 			"${WORKDIR}/copium/cr149-unbundle-minizip-undo-unicode.patch"
 		)
 
-		if ver_test "${RUST_VERSION}" -ge "1.95.0"; then
+		if ver_test "${RUST_SLOT}" -ge "1.95.0"; then
 			PATCHES+=( "${FILESDIR}/fix-rust-1.95-bytemuck.patch" )
 		fi
 

--- a/www-client/ungoogled-chromium/ungoogled-chromium-149.0.7827.196_p1.ebuild
+++ b/www-client/ungoogled-chromium/ungoogled-chromium-149.0.7827.196_p1.ebuild
@@ -733,6 +733,10 @@ src_prepare() {
 			"${WORKDIR}/copium/cr149-unbundle-minizip-undo-unicode.patch"
 		)
 
+		if ver_test "${RUST_VERSION}" -ge "1.95.0"; then
+			PATCHES+=( "${FILESDIR}/fix-rust-1.95-bytemuck.patch" )
+		fi
+
 		# Automate conditional application of chromium-patches
 		# The directory structure is expected to be something like:
 		# chromium-patches-145/


### PR DESCRIPTION
Fixes the error reported in #496 by applying [this patch](https://aur.archlinux.org/cgit/aur.git/plain/chromium-147-rust-1.95-bytemuck.patch?h=ungoogled-chromium) (also used in [Void's packages](https://github.com/void-linux/void-packages/pull/60078))